### PR TITLE
docs: add localized guides and automated validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,32 @@
+name: Validate Skill
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run deterministic tests
+        run: python -m unittest discover -s tests -v
+
+      - name: Compile response validator
+        run: python -m py_compile scripts/validate_booking.py
+
+      - name: Check patch formatting
+        run: git diff --check

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ SKILL.zh-CN.md
 EVAL_GUIDE.md
 TEST_REPORT.md
 evals/
-scripts/validate_booking.py

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,126 @@
+# Skill de reservas de hotel de TourMind
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md)
+
+Convierte cualquier agente de IA en un asistente integral de reservas de hotel: busca inventario global, compara tarifas en tiempo real entre las principales OTA y proveedores hoteleros, verifica disponibilidad y completa reservas, pagos, cancelaciones y gestión de pedidos en una sola conversación con TourMind.
+
+## Demostración
+
+> **Pendiente:** Añadir una captura real o un GIF corto del flujo completo: búsqueda de hoteles, tarifas de habitaciones en tiempo real, verificación final de precio y disponibilidad, y reserva.
+
+## Capacidades principales
+
+- Resuelve ciudades, hoteles, lugares de interés, estaciones, direcciones, zonas de esquí y otros POI sin inventar coordenadas.
+- Busca hasta 20 hoteles candidatos, consulta productos de habitación en tiempo real y selecciona las cinco mejores opciones verificadas.
+- Compara tarifas por noche y totales de estancia entre las principales OTA y proveedores hoteleros, junto con cancelación y estado del inventario.
+- Devuelve imágenes de hoteles y habitaciones, instalaciones, camas, comidas, cargos y motivos de selección basados en datos.
+- Vuelve a verificar el precio y la disponibilidad de la habitación elegida antes de reservar.
+- Crea reservas, consulta y cancela pedidos e inicia pagos con Stripe, WeChat Pay o Alipay.
+- Proporciona enlaces de resultados de solo lectura, reutilizables hasta su vencimiento, sin exponer el Skill Token.
+
+## Clientes de IA compatibles
+
+| Cliente | Compatibilidad |
+|---|---|
+| OpenAI Codex | Compatible como Skill local instalado en `~/.codex/skills` |
+| Clientes compatibles con Agent Skills | Compatible cuando el cliente puede cargar un `SKILL.md` en la raíz y realizar solicitudes HTTPS `POST` |
+| Clientes de IA compatibles con MCP | Utiliza el paquete complementario [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) |
+
+## Instalación en 1 minuto
+
+1. Clona el Skill en Codex:
+
+   ```bash
+   mkdir -p ~/.codex/skills
+   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git ~/.codex/skills/tourmind-booking
+   ```
+
+2. Genera un Skill Token en [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token), guarda el token sin modificar como `~/.codex/skills/tourmind-booking/skill_token.txt` y restringe el acceso:
+
+   ```bash
+   chmod 600 ~/.codex/skills/tourmind-booking/skill_token.txt
+   ```
+
+3. Reinicia el cliente de IA y solicita un hotel. No se necesita un servidor MCP local; este Skill llama directamente a la API de TourMind mediante HTTPS.
+
+Nunca confirmes `skill_token.txt` en Git. El archivo está excluido por `.gitignore`.
+
+## Prompts de ejemplo
+
+```text
+Busca un hotel a menos de 3 km de la estación de metro Xili en Shenzhen para dos adultos, del 12 al 14 de septiembre.
+```
+
+```text
+Muéstrame los cinco mejores hoteles con tarifas de habitación verificadas en tiempo real, desayuno, condiciones de cancelación y total de la estancia.
+```
+
+```text
+Muestra todos los candidatos devueltos por la búsqueda y marca claramente los que no cumplan mis requisitos obligatorios.
+```
+
+```text
+Vuelve a verificar la habitación seleccionada y ayúdame a reservar y pagar después de que confirme el precio final y la política de cancelación.
+```
+
+## Flujo de trabajo
+
+```text
+Ubicación o POI
+  → search_location
+  → search_hotels (hasta 20 candidatos)
+  → query_room_rates (productos en tiempo real para candidatos elegibles)
+  → ordenar y mostrar los cinco mejores hoteles verificados
+  → get_hotel_detail + imágenes y tarifas de habitaciones
+  → check_room_availability para la tarifa seleccionada
+  → create_booking tras una confirmación explícita
+  → pay_order / query_booking / cancel_booking según la solicitud
+```
+
+El valor almacenado en caché `search_hotels.min_price` es únicamente una señal para seleccionar candidatos. Los precios mostrados proceden de `query_room_rates` y la reserva final utiliza los valores más recientes de `check_room_availability`.
+
+## Token y seguridad
+
+- Todas las llamadas a la API del Skill ToB requieren el Skill Token guardado localmente en `skill_token.txt`.
+- No incluyas el Token en prompts, registros, capturas, URL, commits ni informes de incidencias.
+- Limita el archivo del Token al usuario actual mediante `chmod 600`.
+- Si recibes HTTP 401 o `unauthorized`, elimina el Token local no válido y genera uno nuevo.
+- Las sesiones `web_url` son de solo lectura y pueden abrirse varias veces hasta su vencimiento; no permiten verificar tarifas, reservar, pagar, cancelar ni acceder a páginas de cuenta o finanzas.
+- Las reservas, cancelaciones y pagos requieren confirmación explícita del usuario dentro de la conversación de IA autenticada.
+
+## Elige la integración de TourMind adecuada
+
+| Audiencia | Integración | Modelo de autenticación | Repositorio |
+|---|---|---|---|
+| Consumidor / ToC | Skill HTTP directo | Búsqueda y disponibilidad públicas; `user_key` solo para operaciones de pedidos | [Hotel Booking AI](https://github.com/tourmind-com/Hotel-Booking-AI) |
+| Empresa / ToB | Skill HTTP directo | Skill Token obligatorio en cada llamada a la API | **[TourMind Booking Skill](https://github.com/tourmind-com/Tourmind-Booking-Skill)** |
+| Consumidor / ToC | MCP + Skill complementario | Conexión MCP pública; `user_key` solo para operaciones de pedidos | [Hotel Booking AI MCP](https://github.com/tourmind-com/Hotel-Booking-AI-MCP) |
+| Empresa / ToB | MCP + Skill complementario | Conexión MCP autenticada mediante Bearer | [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) |
+
+## API y soporte
+
+**URL base de la API:** `https://api.tourmind.com`
+
+| Endpoint | Propósito |
+|---|---|
+| `POST /skill/tob/check_skill_update` | Comprobar actualizaciones del Skill |
+| `POST /skill/tob/search_location` | Resolver una región, un POI o un hotel |
+| `POST /skill/tob/search_hotels` | Buscar hoteles candidatos |
+| `POST /skill/tob/get_hotel_detail` | Obtener detalles e imágenes del hotel |
+| `POST /skill/tob/query_room_rates` | Obtener habitaciones y tarifas en tiempo real |
+| `POST /skill/tob/check_room_availability` | Volver a verificar la tarifa y el inventario elegidos |
+| `POST /skill/tob/create_booking` | Crear una reserva confirmada |
+| `POST /skill/tob/query_booking` | Consultar un pedido |
+| `POST /skill/tob/cancel_booking` | Cancelar un pedido tras confirmación |
+| `POST /skill/tob/pay_order` | Iniciar el pago tras confirmación |
+
+- Campos y contratos de respuesta: [references/parameter_guide.md](references/parameter_guide.md)
+- Skill Token: [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token)
+- Página del producto: [tourmind.com/skill](https://tourmind.com/skill)
+- Soporte en GitHub: [abrir una incidencia](https://github.com/tourmind-com/Tourmind-Booking-Skill/issues)
+- Consultas sobre hoteles: `hotel@tourmind.com`
+- Colaboración comercial: `bp@tourmind.com`
+
+## Licencia
+
+[MIT](LICENSE) © 2026 TourMind

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,126 @@
+# TourMind ホテル予約 Skill
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md)
+
+あらゆる AI エージェントをエンドツーエンドのホテル予約アシスタントに変えます。世界中のホテル在庫を検索し、主要 OTA とホテルサプライヤーのリアルタイム料金を比較し、空室を確認して、TourMind との1回の会話で予約、決済、キャンセル、注文管理まで完了できます。
+
+## デモ
+
+> **追加予定：** ホテル検索、リアルタイム客室料金、最終的な料金・空室確認、予約までを示す実際のスクリーンショットまたは短い GIF を追加します。
+
+## 主な機能
+
+- 都市、ホテル、ランドマーク、駅、住所、スキー場などの POI を、座標を推測せずに解決します。
+- 最大 20 件のホテル候補を検索し、条件に合うリアルタイム客室商品を照会して、検証済みの上位 5 件を選択します。
+- 主要 OTA とホテルサプライヤーの1泊料金、滞在合計、キャンセル条件、在庫状態をリアルタイムで比較します。
+- ホテル・客室画像、設備、ベッド、食事、料金情報、根拠に基づくおすすめ理由を返します。
+- 予約前に、選択した客室の料金と空室状況を再確認します。
+- 予約作成、注文照会・キャンセル、Stripe、WeChat Pay、Alipay の支払い開始に対応します。
+- Skill Token を公開せず、有効期限内に繰り返し開ける読み取り専用結果リンクを提供します。
+
+## 対応 AI クライアント
+
+| クライアント | 対応方法 |
+|---|---|
+| OpenAI Codex | `~/.codex/skills` にローカル Skill としてインストール |
+| Agent Skills 互換クライアント | ルートの `SKILL.md` を読み込み、HTTPS `POST` リクエストを送信できる場合に利用可能 |
+| MCP 対応 AI クライアント | 付属の [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) パッケージを使用 |
+
+## 1分でインストール
+
+1. Skill を Codex にクローンします。
+
+   ```bash
+   mkdir -p ~/.codex/skills
+   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git ~/.codex/skills/tourmind-booking
+   ```
+
+2. [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token) で Skill Token を生成し、トークン本体を `~/.codex/skills/tourmind-booking/skill_token.txt` に保存して、アクセス権を制限します。
+
+   ```bash
+   chmod 600 ~/.codex/skills/tourmind-booking/skill_token.txt
+   ```
+
+3. AI クライアントを再起動し、ホテルを依頼します。ローカル MCP サーバーは不要で、この Skill は HTTPS で TourMind API を直接呼び出します。
+
+`skill_token.txt` は絶対にコミットしないでください。このファイルは `.gitignore` で除外されています。
+
+## プロンプト例
+
+```text
+9月12日から9月14日まで、大人2名で、深圳の西麗地下鉄駅から3 km以内のホテルを探してください。
+```
+
+```text
+確認済みのリアルタイム客室料金、朝食、キャンセル条件、滞在合計を含めて、最適なホテルを5件表示してください。
+```
+
+```text
+ホテル検索で返された候補をすべて表示し、必須条件を満たさない候補には理由を明記してください。
+```
+
+```text
+選択した客室を再確認し、最終料金とキャンセル条件を私が確認した後に予約と支払いを手伝ってください。
+```
+
+## ワークフロー
+
+```text
+場所または POI
+  → search_location
+  → search_hotels（最大 20 件）
+  → query_room_rates（対象候補のリアルタイム客室商品）
+  → 検証済み上位 5 ホテルを順位付けして表示
+  → get_hotel_detail + 客室画像と料金
+  → 選択料金に対して check_room_availability
+  → 明示的な確認後に create_booking
+  → 必要に応じて pay_order / query_booking / cancel_booking
+```
+
+キャッシュされた `search_hotels.min_price` は候補選定用の参考値です。ユーザーに表示する料金は `query_room_rates` から取得し、予約には `check_room_availability` が返す最新の値を使用します。
+
+## Token とセキュリティ
+
+- すべての ToB Skill API 呼び出しには、ローカルの `skill_token.txt` に保存した Skill Token が必要です。
+- Token をプロンプト、ログ、スクリーンショット、URL、コミット、Issue に含めないでください。
+- `chmod 600` を使用して、Token ファイルを現在のユーザーだけが読み書きできるようにします。
+- HTTP 401 または `unauthorized` が返された場合は、無効なローカル Token を削除して再発行します。
+- 結果の `web_url` は読み取り専用で、有効期限までは繰り返し開けます。料金再確認、予約、決済、キャンセル、アカウント・財務ページへのアクセスはできません。
+- 予約、キャンセル、決済は、認証済み AI 会話内でユーザーが明示的に確認した場合のみ実行します。
+
+## Skill / MCP / ToB / ToC の選択
+
+| 対象 | 接続方式 | 認証モデル | リポジトリ |
+|---|---|---|---|
+| コンシューマー / ToC | 直接 HTTP Skill | 検索・空室確認は公開、注文操作のみ `user_key` が必要 | [Hotel Booking AI](https://github.com/tourmind-com/Hotel-Booking-AI) |
+| ビジネス / ToB | 直接 HTTP Skill | すべての API 呼び出しに Skill Token が必要 | **[TourMind Booking Skill](https://github.com/tourmind-com/Tourmind-Booking-Skill)** |
+| コンシューマー / ToC | MCP + 付属 Skill | MCP 接続は公開、注文操作のみ `user_key` が必要 | [Hotel Booking AI MCP](https://github.com/tourmind-com/Hotel-Booking-AI-MCP) |
+| ビジネス / ToB | MCP + 付属 Skill | Bearer 認証された MCP 接続 | [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) |
+
+## API とサポート
+
+**API ベース URL:** `https://api.tourmind.com`
+
+| エンドポイント | 用途 |
+|---|---|
+| `POST /skill/tob/check_skill_update` | Skill の更新確認 |
+| `POST /skill/tob/search_location` | 地域、POI、ホテルの解決 |
+| `POST /skill/tob/search_hotels` | ホテル候補の検索 |
+| `POST /skill/tob/get_hotel_detail` | ホテル詳細と画像の取得 |
+| `POST /skill/tob/query_room_rates` | リアルタイム客室と料金の取得 |
+| `POST /skill/tob/check_room_availability` | 選択料金と在庫の再確認 |
+| `POST /skill/tob/create_booking` | 確認済み予約の作成 |
+| `POST /skill/tob/query_booking` | 注文の照会 |
+| `POST /skill/tob/cancel_booking` | 確認後の注文キャンセル |
+| `POST /skill/tob/pay_order` | 確認後の支払い開始 |
+
+- リクエスト項目とレスポンス契約：[references/parameter_guide.md](references/parameter_guide.md)
+- Skill Token：[tourmind.com/user/skill-token](https://tourmind.com/user/skill-token)
+- 製品ページ：[tourmind.com/skill](https://tourmind.com/skill)
+- GitHub サポート：[Issue を作成](https://github.com/tourmind-com/Tourmind-Booking-Skill/issues)
+- ホテル事業に関するお問い合わせ：`hotel@tourmind.com`
+- ビジネス提携：`bp@tourmind.com`
+
+## ライセンス
+
+[MIT](LICENSE) © 2026 TourMind

--- a/README.md
+++ b/README.md
@@ -1,94 +1,126 @@
 # TourMind Booking Skill
 
-TourMind's end-to-end hotel booking skill for AI clients. It supports POI resolution, live hotel and room comparison, rate verification, booking, order management, cancellation, and payment.
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md)
 
-## Features
+Turn any AI agent into an end-to-end hotel booking assistant—search global inventory, compare live rates across leading OTAs and hotel suppliers, verify availability, and complete booking, payment, cancellation, and order management in one conversation with TourMind.
 
-- Resolves cities, hotels, landmarks, stations, and other POIs without inventing coordinates.
-- Verifies up to 20 hotel candidates against live room products and selects the five best matches.
-- Returns consistent hotel cards with images, distance, live prices, cancellation terms, tax status, and evidence-based match reasons.
-- Returns hotel details, room images, beds, meals, live quotes, and cancellation terms together.
-- Rechecks price and availability before booking.
-- Creates bookings after collecting the guest's legal name and required contact email.
-- Queries and cancels existing bookings.
-- Starts Stripe, WeChat Pay, or Alipay payments and discloses Stripe's 3.5% processing fee when applicable.
+## Demo
 
-## Installable contents
+> **TODO:** Add a real end-to-end screenshot or short GIF showing hotel search, live room rates, final availability verification, and booking.
 
+## Core capabilities
+
+- Resolve cities, hotels, landmarks, stations, addresses, ski areas, and other POIs without inventing coordinates.
+- Search up to 20 hotel candidates, query matching live room products, and select the five best verified options.
+- Compare live nightly and stay-total rates across leading OTAs and hotel suppliers, including cancellation and inventory status.
+- Return hotel and room images, facilities, beds, meals, fees, and evidence-based match reasons.
+- Recheck the selected room's price and availability before booking.
+- Create bookings, query and cancel orders, and start Stripe, WeChat Pay, or Alipay payments.
+- Provide expiring, repeatable, read-only result links without exposing the Skill Token.
+
+## Supported AI clients
+
+| Client | Support |
+|---|---|
+| OpenAI Codex | Supported as a local Skill installed under `~/.codex/skills` |
+| Agent Skills-compatible clients | Compatible when the client can load a root `SKILL.md` and make outbound HTTPS `POST` requests |
+| MCP-capable AI clients | Use the companion [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) package |
+
+## Install in 1 minute
+
+1. Clone the Skill into Codex:
+
+   ```bash
+   mkdir -p ~/.codex/skills
+   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git ~/.codex/skills/tourmind-booking
+   ```
+
+2. Generate a Skill Token at [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token), save the raw token as `~/.codex/skills/tourmind-booking/skill_token.txt`, and restrict access:
+
+   ```bash
+   chmod 600 ~/.codex/skills/tourmind-booking/skill_token.txt
+   ```
+
+3. Restart the AI client and ask for a hotel. No local MCP server is required; this Skill calls the TourMind API directly over HTTPS.
+
+Never commit `skill_token.txt`. It is excluded by `.gitignore`.
+
+## Example prompts
+
+```text
+Find a hotel near Shenzhen Xili Metro Station for two adults from September 12 to September 14, within 3 km.
 ```
-├── .gitignore
-├── LICENSE
-├── README.md
-├── SKILL.md
-├── references/
-│   └── parameter_guide.md
+
+```text
+Show the best five hotels with verified live room rates, breakfast, cancellation terms, and stay totals.
 ```
 
-Evaluation fixtures, test reports, review translations, and development-only validators are intentionally excluded from the installable release.
-
-## Installation
-
-Clone the repository into your AI client's skills directory:
-
-```bash
-mkdir -p ~/.codex/skills
-git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git ~/.codex/skills/tourmind-booking
+```text
+Show every candidate returned by the hotel search and clearly label any option that failed my hard constraints.
 ```
 
-Generate a Skill Token at `https://tourmind.com/user/skill-token`, save it as `skill_token.txt` in the installed skill directory, and restrict its permissions:
-
-```bash
-chmod 600 ~/.codex/skills/tourmind-booking/skill_token.txt
+```text
+Recheck the selected room, then help me book and pay after I confirm the final price and cancellation policy.
 ```
 
-The token file is excluded by `.gitignore` and must never be committed. Restart the AI client or gateway after installation. No local MCP server is required; the skill calls the TourMind Skill API directly over HTTP.
+## Workflow
 
-## API
+```text
+Location or POI
+  → search_location
+  → search_hotels (up to 20 candidates)
+  → query_room_rates (live products for eligible candidates)
+  → rank and present the five best verified hotels
+  → get_hotel_detail + room images and quotes
+  → check_room_availability for the selected rate
+  → create_booking after explicit confirmation
+  → pay_order / query_booking / cancel_booking as requested
+```
 
-**Base URL:** `https://api.tourmind.com`
+Cached `search_hotels.min_price` is only a candidate signal. User-visible prices come from `query_room_rates`, and the final booking uses the latest values returned by `check_room_availability`.
+
+## Token and security
+
+- All ToB Skill API calls require the Skill Token stored locally in `skill_token.txt`.
+- Keep the token out of prompts, logs, screenshots, URLs, commits, and issue reports.
+- Restrict the token file to the current user with `chmod 600`.
+- On HTTP 401 or an `unauthorized` response, remove the invalid local token and generate a replacement.
+- Result `web_url` sessions are read-only and can be opened repeatedly until they expire; they cannot verify rates, book, pay, cancel, or access account and finance pages.
+- Booking, cancellation, and payment remain explicit user-confirmed actions inside the authenticated AI conversation.
+
+## Choose the right TourMind integration
+
+| Audience | Integration | Authentication model | Repository |
+|---|---|---|---|
+| Consumer / ToC | Direct HTTP Skill | Public search and availability; `user_key` only for order operations | [Hotel Booking AI](https://github.com/tourmind-com/Hotel-Booking-AI) |
+| Business / ToB | Direct HTTP Skill | Skill Token required for every API call | **[TourMind Booking Skill](https://github.com/tourmind-com/Tourmind-Booking-Skill)** |
+| Consumer / ToC | MCP package + companion Skill | Public MCP connection; `user_key` only for order operations | [Hotel Booking AI MCP](https://github.com/tourmind-com/Hotel-Booking-AI-MCP) |
+| Business / ToB | MCP package + companion Skill | Bearer-authenticated MCP connection | [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) |
+
+## API and support
+
+**API base URL:** `https://api.tourmind.com`
 
 | Endpoint | Purpose |
 |---|---|
-| `POST /skill/tob/check_skill_update` | Check whether the installed Skill has an update |
+| `POST /skill/tob/check_skill_update` | Check for a Skill update |
 | `POST /skill/tob/search_location` | Resolve a region, POI, or hotel |
 | `POST /skill/tob/search_hotels` | Search hotel candidates |
 | `POST /skill/tob/get_hotel_detail` | Get hotel details and images |
 | `POST /skill/tob/query_room_rates` | Get live rooms and rates |
-| `POST /skill/tob/check_room_availability` | Recheck price and availability |
-| `POST /skill/tob/create_booking` | Create a booking |
-| `POST /skill/tob/query_booking` | Query a booking |
-| `POST /skill/tob/cancel_booking` | Cancel a booking |
-| `POST /skill/tob/pay_order` | Start payment |
+| `POST /skill/tob/check_room_availability` | Recheck the selected rate and inventory |
+| `POST /skill/tob/create_booking` | Create a confirmed booking |
+| `POST /skill/tob/query_booking` | Query an order |
+| `POST /skill/tob/cancel_booking` | Cancel an order after confirmation |
+| `POST /skill/tob/pay_order` | Start payment after confirmation |
 
-Every request body must include the `token` generated in the customer portal. The authoritative Skill version is declared immediately below the title in `SKILL.md`. Send it as `current_version` only to `check_skill_update`: once when the Skill is first used in a new conversation, and again when an existing conversation resumes after at least 24 hours of inactivity.
+- Request fields and response contracts: [references/parameter_guide.md](references/parameter_guide.md)
+- Skill Token: [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token)
+- Product page: [tourmind.com/skill](https://tourmind.com/skill)
+- GitHub support: [open an issue](https://github.com/tourmind-com/Tourmind-Booking-Skill/issues)
+- Hotel business inquiry: `hotel@tourmind.com`
+- Business cooperation: `bp@tourmind.com`
 
-## Example
+## License
 
-```
-User: Find a hotel in Tokyo for two adults from April 28 to April 30.
-
-Assistant: TourMind returned 20 candidates. I verified live rooms and rates and selected the five best matches.
-
-           1. Example Hotel
-           [hotel hero image]
-           Lowest matching live rate: JPY 18,000 per night; JPY 36,000 total
-           Why it matches: low verified total in this set; fits two adults; immediately bookable inventory.
-
-           I can also show the remaining candidates or the complete returned pool.
-
-User: Show me the standard rooms at the second hotel.
-
-Assistant: Here are the hotel's details, room images, and current matching quotes. Choose a room and I will perform a final price and availability check.
-
-User: Book the standard king room.
-
-Assistant: Please provide the guest's full legal name and a contact email. The email is required for booking status and cancellation notifications.
-
-User: Alex Smith, guest@example.com
-
-Assistant: Booking created. TourMind order number: TM20260428001. Choose Stripe, WeChat Pay, or Alipay.
-```
-
-## API reference
-
-See [references/parameter_guide.md](references/parameter_guide.md) for request fields, POI proxy logic, candidate ranking, image mapping, taxes, and booking rules. Resolve city and region IDs through the live `search_location` endpoint instead of relying on hardcoded values.
+[MIT](LICENSE) © 2026 TourMind

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,126 @@
+# TourMind 酒店预订 Skill
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md)
+
+让任何 AI Agent 在一次对话中获得端到端酒店预订能力：搜索全球酒店资源、比较主流 OTA 与酒店供应商的实时价格、核验库存，并通过 TourMind 完成预订、支付、取消和订单管理。
+
+## 示例截图
+
+> **待补充：** 增加一张真实的端到端截图或短 GIF，展示酒店搜索、实时房价、最终库存验价和预订流程。
+
+## 核心能力
+
+- 解析城市、酒店、地标、车站、地址、滑雪场等 POI，不凭空编造坐标。
+- 搜索最多 20 家候选酒店，查询匹配的实时房型，并选出经过验证的最佳 5 家。
+- 比较主流 OTA 和酒店供应商的实时每晚价格、总价、取消政策及库存状态。
+- 同时返回酒店与房型图片、设施、床型、餐食、费用和基于证据的推荐理由。
+- 下单前重新核验所选房型的价格和库存。
+- 创建预订、查询与取消订单，并发起 Stripe、微信支付或支付宝付款。
+- 提供有时效、可重复访问的只读结果链接，同时不暴露 Skill Token。
+
+## 支持的 AI 客户端
+
+| 客户端 | 支持方式 |
+|---|---|
+| OpenAI Codex | 作为本地 Skill 安装到 `~/.codex/skills` |
+| 兼容 Agent Skills 的客户端 | 客户端能够加载根目录 `SKILL.md` 并发起 HTTPS `POST` 请求时可用 |
+| 支持 MCP 的 AI 客户端 | 使用配套的 [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) |
+
+## 1 分钟安装
+
+1. 将 Skill 克隆到 Codex：
+
+   ```bash
+   mkdir -p ~/.codex/skills
+   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git ~/.codex/skills/tourmind-booking
+   ```
+
+2. 前往 [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token) 生成 Skill Token，将原始 Token 保存为 `~/.codex/skills/tourmind-booking/skill_token.txt`，然后限制文件权限：
+
+   ```bash
+   chmod 600 ~/.codex/skills/tourmind-booking/skill_token.txt
+   ```
+
+3. 重启 AI 客户端并提出酒店需求。无需在本地运行 MCP 服务，本 Skill 会通过 HTTPS 直接调用 TourMind API。
+
+切勿提交 `skill_token.txt`；该文件已经被 `.gitignore` 排除。
+
+## 示例 Prompt
+
+```text
+帮我搜索深圳西丽地铁站附近、9月12日至9月14日入住、2位成人、3公里以内的酒店。
+```
+
+```text
+给我展示最合适的5家酒店，包含经过验证的实时房价、早餐、取消政策和入住总价。
+```
+
+```text
+把酒店搜索接口返回的全部候选都列出来，不符合硬性条件的酒店请明确标注原因。
+```
+
+```text
+重新核验我选中的房型；确认最终价格和取消政策后，再协助我预订和支付。
+```
+
+## 工作流程
+
+```text
+地点或 POI
+  → search_location
+  → search_hotels（最多 20 家候选）
+  → query_room_rates（查询符合条件候选的实时房型）
+  → 排序并展示经过验证的最佳 5 家酒店
+  → get_hotel_detail + 房型图片与报价
+  → check_room_availability（核验所选房价）
+  → 用户明确确认后 create_booking
+  → 按需调用 pay_order / query_booking / cancel_booking
+```
+
+`search_hotels.min_price` 只是缓存的候选信号。展示给用户的价格必须来自 `query_room_rates`，最终下单必须使用 `check_room_availability` 返回的最新价格和房价代码。
+
+## Token 与安全说明
+
+- 所有 ToB Skill API 调用都需要保存在本地 `skill_token.txt` 中的 Skill Token。
+- 不要在 Prompt、日志、截图、URL、Git 提交或 Issue 中暴露 Token。
+- 使用 `chmod 600` 将 Token 文件权限限制为仅当前用户可读写。
+- 收到 HTTP 401 或 `unauthorized` 响应时，删除失效的本地 Token 并重新生成。
+- 返回的 `web_url` 会话是只读的，在过期前可重复打开；页面不能验价、预订、支付、取消，也不能访问账户或财务功能。
+- 预订、取消和支付必须在已认证的 AI 对话中获得用户明确确认。
+
+## Skill / MCP / ToB / ToC 选择矩阵
+
+| 用户类型 | 接入方式 | 鉴权模式 | 仓库 |
+|---|---|---|---|
+| 消费者 / ToC | 直连 HTTP Skill | 搜索与验价公开；订单操作才需要 `user_key` | [Hotel Booking AI](https://github.com/tourmind-com/Hotel-Booking-AI) |
+| 企业 / ToB | 直连 HTTP Skill | 每次 API 调用都需要 Skill Token | **[TourMind Booking Skill](https://github.com/tourmind-com/Tourmind-Booking-Skill)** |
+| 消费者 / ToC | MCP + 配套 Skill | MCP 连接公开；订单操作才需要 `user_key` | [Hotel Booking AI MCP](https://github.com/tourmind-com/Hotel-Booking-AI-MCP) |
+| 企业 / ToB | MCP + 配套 Skill | MCP 连接使用 Bearer 鉴权 | [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) |
+
+## API 与支持入口
+
+**API 基础地址：** `https://api.tourmind.com`
+
+| 接口 | 用途 |
+|---|---|
+| `POST /skill/tob/check_skill_update` | 检查 Skill 更新 |
+| `POST /skill/tob/search_location` | 解析地区、POI 或酒店 |
+| `POST /skill/tob/search_hotels` | 搜索候选酒店 |
+| `POST /skill/tob/get_hotel_detail` | 获取酒店详情和图片 |
+| `POST /skill/tob/query_room_rates` | 获取实时房型和价格 |
+| `POST /skill/tob/check_room_availability` | 重新核验所选房价和库存 |
+| `POST /skill/tob/create_booking` | 创建已确认的预订 |
+| `POST /skill/tob/query_booking` | 查询订单 |
+| `POST /skill/tob/cancel_booking` | 确认后取消订单 |
+| `POST /skill/tob/pay_order` | 确认后发起支付 |
+
+- 请求字段与响应契约：[references/parameter_guide.md](references/parameter_guide.md)
+- 获取 Skill Token：[tourmind.com/user/skill-token](https://tourmind.com/user/skill-token)
+- 产品页面：[tourmind.com/skill](https://tourmind.com/skill)
+- GitHub 支持：[提交 Issue](https://github.com/tourmind-com/Tourmind-Booking-Skill/issues)
+- 酒店业务咨询：`hotel@tourmind.com`
+- 商务合作：`bp@tourmind.com`
+
+## 开源许可
+
+[MIT](LICENSE) © 2026 TourMind

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TourMind Hotel Booking"
+  short_description: "Live hotel search, rates, booking, and payment"
+  default_prompt: "Use $tourmind-booking to find and book a hotel for my trip."

--- a/scripts/validate_booking.py
+++ b/scripts/validate_booking.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Validate representative TourMind Skill API responses.
+
+Usage:
+    python3 scripts/validate_booking.py auto '<json_response>'
+    python3 scripts/validate_booking.py search '<json_response>'
+    python3 scripts/validate_booking.py rates '<json_response>'
+    python3 scripts/validate_booking.py detail '<json_response>'
+    python3 scripts/validate_booking.py booking '<json_response>'
+
+The validator checks current ToB response shapes. It does not call live APIs or
+create bookings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+Result = Dict[str, Any]
+
+
+def _result(kind: str, errors: List[str], warnings: List[str], **extra: Any) -> Result:
+    return {
+        "kind": kind,
+        "valid": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        **extra,
+    }
+
+
+def _require_fields(value: Dict[str, Any], fields: Iterable[str], path: str) -> List[str]:
+    return [f"{path} missing required field: {field}" for field in fields if field not in value]
+
+
+def _is_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _is_nonnegative_number(value: Any) -> bool:
+    return _is_number(value) and value >= 0
+
+
+def _is_nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_identifier(value: Any) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value >= 0
+    ) or _is_nonempty_string(value)
+
+
+def _valid_image_url(value: Any) -> bool:
+    return _is_nonempty_string(value) and value.startswith(("http://", "https://"))
+
+
+def _has_group_image(image_groups: Any) -> bool:
+    if not isinstance(image_groups, list):
+        return False
+    for group in image_groups:
+        if not isinstance(group, dict):
+            continue
+        images = group.get("images")
+        if not isinstance(images, list):
+            continue
+        for image in images:
+            if not isinstance(image, dict):
+                continue
+            links = image.get("links")
+            if not isinstance(links, dict):
+                continue
+            for link in links.values():
+                if isinstance(link, dict) and (
+                    _valid_image_url(link.get("href"))
+                    or _valid_image_url(link.get("local_href"))
+                ):
+                    return True
+    return False
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"Non-standard JSON numeric constant: {value}")
+
+
+def _unwrap(response: Any) -> Tuple[Any, List[str], List[str]]:
+    errors: List[str] = []
+    warnings: List[str] = []
+    if not isinstance(response, dict):
+        return response, errors, warnings
+
+    if "ok" not in response:
+        warnings.append("Response has no top-level 'ok' field; validating as raw data")
+        return response.get("data", response), errors, warnings
+
+    if response.get("ok") is not True:
+        error = response.get("error")
+        errors.append(f"API response is not successful: {error!r}")
+        return response.get("data"), errors, warnings
+
+    if "data" not in response:
+        errors.append("Successful API response missing top-level data")
+        return None, errors, warnings
+    return response["data"], errors, warnings
+
+
+def validate_search_response(response: Any) -> Result:
+    data, errors, warnings = _unwrap(response)
+    if isinstance(data, list):
+        hotels = data
+    elif isinstance(data, dict):
+        hotels = data.get("hotels")
+    else:
+        hotels = None
+
+    if not isinstance(hotels, list):
+        errors.append("search data.hotels must be a list")
+        return _result("search", errors, warnings, hotel_count=0)
+
+    for index, hotel in enumerate(hotels):
+        path = f"hotels[{index}]"
+        if not isinstance(hotel, dict):
+            errors.append(f"{path} must be an object")
+            continue
+        errors.extend(_require_fields(hotel, ["hotel_id"], path))
+        if "hotel_id" in hotel and not _is_identifier(hotel["hotel_id"]):
+            errors.append(f"{path}.hotel_id must be a non-empty string or non-negative integer")
+        if not any(hotel.get(key) for key in ("hotel_name_cn", "hotel_name", "name_cn", "name")):
+            errors.append(f"{path} missing a usable hotel name")
+        if "distance_km" in hotel and not _is_nonnegative_number(hotel["distance_km"]):
+            errors.append(f"{path}.distance_km must be a finite non-negative number")
+        if "min_price" in hotel and not _is_nonnegative_number(hotel["min_price"]):
+            errors.append(f"{path}.min_price must be a finite non-negative number")
+        if "min_price" in hotel:
+            warnings.append(f"{path}.min_price is cached and must not be presented as a live quote")
+            if not _is_nonempty_string(hotel.get("currency_code")):
+                errors.append(f"{path}.currency_code must be a non-empty string when min_price is present")
+
+    if len(hotels) > 20:
+        errors.append(f"search returned {len(hotels)} hotels; endpoint contract allows at most 20")
+    if not hotels:
+        warnings.append("No hotel candidates returned; this may be valid for the constraints")
+    return _result("search", errors, warnings, hotel_count=len(hotels))
+
+
+def _iter_products(room_types: List[Any]) -> Iterable[Tuple[str, Dict[str, Any]]]:
+    for room_index, room in enumerate(room_types):
+        if not isinstance(room, dict):
+            continue
+        products = room.get("products", [])
+        if not isinstance(products, list):
+            continue
+        for product_index, product in enumerate(products):
+            if isinstance(product, dict):
+                yield f"room_types[{room_index}].products[{product_index}]", product
+
+
+def validate_rates_response(response: Any) -> Result:
+    data, errors, warnings = _unwrap(response)
+    room_types = data.get("room_types") if isinstance(data, dict) else None
+    if not isinstance(room_types, list):
+        errors.append("rates data.room_types must be a list")
+        return _result("rates", errors, warnings, room_type_count=0, product_count=0)
+
+    for index, room in enumerate(room_types):
+        path = f"room_types[{index}]"
+        if not isinstance(room, dict):
+            errors.append(f"{path} must be an object")
+            continue
+        if not any(room.get(key) for key in ("name_cn", "name")):
+            warnings.append(f"{path} has no room name; render as 其它/入住时确认房型")
+        if not _valid_image_url(room.get("basic_room_image")):
+            warnings.append(f"{path} has no exact live room image")
+        products = room.get("products", [])
+        if not isinstance(products, list):
+            errors.append(f"{path}.products must be a list")
+            continue
+        for product_index, product in enumerate(products):
+            if not isinstance(product, dict):
+                errors.append(f"{path}.products[{product_index}] must be an object")
+
+    product_count = 0
+    for path, product in _iter_products(room_types):
+        product_count += 1
+        errors.extend(_require_fields(product, ["cancellation_policy", "rate"], path))
+        cancellation = product.get("cancellation_policy")
+        if not isinstance(cancellation, dict):
+            errors.append(f"{path}.cancellation_policy must be an object")
+        else:
+            errors.extend(_require_fields(cancellation, ["type"], f"{path}.cancellation_policy"))
+            if "type" in cancellation and not _is_nonempty_string(cancellation["type"]):
+                errors.append(f"{path}.cancellation_policy.type must be a non-empty string")
+
+        rate = product.get("rate")
+        if not isinstance(rate, dict):
+            errors.append(f"{path}.rate must be an object")
+            continue
+        errors.extend(
+            _require_fields(
+                rate,
+                ["rate_code", "currency", "total_price", "per_night_price", "is_on_request"],
+                f"{path}.rate",
+            )
+        )
+        if "rate_code" in rate and not _is_nonempty_string(rate["rate_code"]):
+            errors.append(f"{path}.rate.rate_code must be a non-empty string")
+        if "currency" in rate and not _is_nonempty_string(rate["currency"]):
+            errors.append(f"{path}.rate.currency must be a non-empty string")
+        for field in ("total_price", "per_night_price"):
+            if field in rate and not _is_nonnegative_number(rate[field]):
+                errors.append(f"{path}.rate.{field} must be a finite non-negative number")
+        if "is_on_request" in rate and not isinstance(rate["is_on_request"], bool):
+            errors.append(f"{path}.rate.is_on_request must be boolean")
+
+    if product_count == 0:
+        errors.append("No usable live products returned; hotel must not be presented as bookable")
+    return _result(
+        "rates",
+        errors,
+        warnings,
+        room_type_count=len(room_types),
+        product_count=product_count,
+        bookable=product_count > 0 and not errors,
+    )
+
+
+def validate_detail_response(response: Any) -> Result:
+    data, errors, warnings = _unwrap(response)
+    hotel = data.get("hotel") if isinstance(data, dict) else None
+    rooms = data.get("rooms", []) if isinstance(data, dict) else []
+    if not isinstance(hotel, dict):
+        errors.append("detail data.hotel must be an object")
+        return _result("detail", errors, warnings, room_count=0)
+
+    errors.extend(_require_fields(hotel, ["hotel_id"], "hotel"))
+    if "hotel_id" in hotel and not _is_identifier(hotel["hotel_id"]):
+        errors.append("hotel.hotel_id must be a non-empty string or non-negative integer")
+    if not any(_is_nonempty_string(hotel.get(key)) for key in ("name_cn", "name")):
+        errors.append("hotel missing a usable name")
+    if not any(_is_nonempty_string(hotel.get(key)) for key in ("address_cn", "address")):
+        warnings.append("hotel has no address")
+
+    image_groups = hotel.get("image_groups")
+    hotel_images = hotel.get("hotel_images")
+    has_image = (
+        _valid_image_url(hotel.get("hotel_image"))
+        or (
+            isinstance(hotel_images, list)
+            and any(_valid_image_url(item) for item in hotel_images)
+        )
+        or _has_group_image(image_groups)
+    )
+    if not has_image:
+        warnings.append("hotel has no hero-image source; output must show an explicit no-image state")
+    if not isinstance(rooms, list):
+        errors.append("detail data.rooms must be a list when present")
+        rooms = []
+    else:
+        for index, room in enumerate(rooms):
+            if not isinstance(room, dict):
+                errors.append(f"rooms[{index}] must be an object")
+    return _result("detail", errors, warnings, room_count=len(rooms), has_image=has_image)
+
+
+def validate_booking_response(response: Any) -> Result:
+    data, errors, warnings = _unwrap(response)
+    if not isinstance(data, dict):
+        errors.append("booking data must be an object")
+        return _result("booking", errors, warnings, agent_ref_id=None)
+
+    errors.extend(_require_fields(data, ["agent_ref_id"], "booking data"))
+    agent_ref_id = data.get("agent_ref_id")
+    if "agent_ref_id" in data and not _is_nonempty_string(agent_ref_id):
+        errors.append("booking data.agent_ref_id must be a non-empty string")
+    if not any(key in data for key in ("status", "message")):
+        warnings.append("booking response has no status/message field")
+    for field in ("status", "message"):
+        if field in data and not _is_nonempty_string(data[field]):
+            errors.append(f"booking data.{field} must be a non-empty string when present")
+    return _result("booking", errors, warnings, agent_ref_id=agent_ref_id)
+
+
+def detect_kind(response: Any) -> Optional[str]:
+    data = response.get("data") if isinstance(response, dict) and "data" in response else response
+    if isinstance(data, list):
+        return "search"
+    if not isinstance(data, dict):
+        return None
+    signatures: List[str] = []
+    if "hotels" in data:
+        signatures.append("search")
+    if "room_types" in data:
+        signatures.append("rates")
+    if "hotel" in data:
+        signatures.append("detail")
+    if "agent_ref_id" in data:
+        signatures.append("booking")
+    return signatures[0] if len(signatures) == 1 else None
+
+
+VALIDATORS = {
+    "search": validate_search_response,
+    "rates": validate_rates_response,
+    "detail": validate_detail_response,
+    "booking": validate_booking_response,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("kind", choices=["auto", *VALIDATORS])
+    parser.add_argument("response_json", help="JSON response string")
+    args = parser.parse_args()
+
+    try:
+        response = json.loads(args.response_json, parse_constant=_reject_json_constant)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"valid": False, "errors": [f"Invalid JSON: {exc}"]}, ensure_ascii=False, indent=2))
+        return 2
+
+    if args.kind == "auto" and isinstance(response, dict) and response.get("ok") is False:
+        result = _result(
+            "api-error",
+            [f"API response is not successful: {response.get('error')!r}"],
+            [],
+        )
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 1
+
+    kind = detect_kind(response) if args.kind == "auto" else args.kind
+    if kind is None:
+        print(
+            json.dumps(
+                {"valid": False, "errors": ["Could not detect response kind; pass an explicit kind"]},
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return 2
+
+    result = VALIDATORS[kind](response)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "SKILL.md"
+READMES = (
+    ROOT / "README.md",
+    ROOT / "README.zh-CN.md",
+    ROOT / "README.ja.md",
+    ROOT / "README.es.md",
+)
+REPOSITORIES = (
+    "tourmind-com/Hotel-Booking-AI",
+    "tourmind-com/Tourmind-Booking-Skill",
+    "tourmind-com/Hotel-Booking-AI-MCP",
+    "tourmind-com/Tourmind-Booking-MCP",
+)
+
+
+class RepositoryContractTests(unittest.TestCase):
+    def test_skill_frontmatter_and_version(self) -> None:
+        text = SKILL.read_text(encoding="utf-8")
+        self.assertTrue(text.startswith("---\n"))
+        frontmatter = text.split("---", 2)[1]
+        top_level_keys = {
+            match.group(1)
+            for line in frontmatter.splitlines()
+            if (match := re.match(r"^([a-z][a-z0-9_-]*):", line))
+        }
+        self.assertEqual(top_level_keys, {"name", "description"})
+        self.assertRegex(frontmatter, r"(?m)^name: tourmind-booking$")
+        self.assertRegex(text, r"\*\*Skill version:\*\* `\d+\.\d+\.\d+`")
+        self.assertLess(len(text.splitlines()), 500)
+
+    def test_skill_references_exist(self) -> None:
+        text = SKILL.read_text(encoding="utf-8")
+        local_markdown_links = re.findall(r"\[[^]]+\]\(([^):]+\.md)\)", text)
+        self.assertTrue(local_markdown_links)
+        for relative_path in local_markdown_links:
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue((ROOT / relative_path).is_file())
+
+    def test_localized_readmes_and_navigation(self) -> None:
+        expected_links = (
+            "README.md",
+            "README.zh-CN.md",
+            "README.ja.md",
+            "README.es.md",
+        )
+        for readme in READMES:
+            with self.subTest(readme=readme.name):
+                text = readme.read_text(encoding="utf-8")
+                for link in expected_links:
+                    self.assertIn(f"]({link})", text)
+                for repository in REPOSITORIES:
+                    self.assertIn(repository, text)
+
+    def test_openai_interface_metadata(self) -> None:
+        metadata = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
+        self.assertIn('display_name: "TourMind Hotel Booking"', metadata)
+        self.assertIn("short_description:", metadata)
+        self.assertIn("$tourmind-booking", metadata)
+
+    def test_required_endpoints_are_documented(self) -> None:
+        text = SKILL.read_text(encoding="utf-8")
+        endpoints = (
+            "check_skill_update",
+            "search_location",
+            "search_hotels",
+            "get_hotel_detail",
+            "query_room_rates",
+            "check_room_availability",
+            "create_booking",
+            "query_booking",
+            "cancel_booking",
+            "pay_order",
+        )
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                self.assertIn(endpoint, text)
+
+    def test_credentials_are_not_tracked(self) -> None:
+        tracked = subprocess.run(
+            ["git", "ls-files"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        self.assertNotIn("skill_token.txt", tracked)
+        self.assertFalse(any(path.endswith("user_key.txt") for path in tracked))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_booking.py
+++ b/tests/test_validate_booking.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.validate_booking import (
+    detect_kind,
+    validate_booking_response,
+    validate_detail_response,
+    validate_rates_response,
+    validate_search_response,
+)
+
+
+class ResponseValidatorTests(unittest.TestCase):
+    def test_valid_search_warns_that_cached_price_is_not_live(self) -> None:
+        result = validate_search_response(
+            {
+                "ok": True,
+                "data": {
+                    "hotels": [
+                        {
+                            "hotel_id": "H1",
+                            "hotel_name": "Example Hotel",
+                            "min_price": 500,
+                            "currency_code": "CNY",
+                            "distance_km": 1.2,
+                        }
+                    ]
+                },
+            }
+        )
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["hotel_count"], 1)
+        self.assertTrue(any("cached" in warning for warning in result["warnings"]))
+
+    def test_search_rejects_more_than_twenty_candidates(self) -> None:
+        hotels = [
+            {"hotel_id": f"H{index}", "hotel_name": f"Hotel {index}"}
+            for index in range(21)
+        ]
+        result = validate_search_response({"ok": True, "data": {"hotels": hotels}})
+        self.assertFalse(result["valid"])
+        self.assertTrue(any("at most 20" in error for error in result["errors"]))
+
+    def test_valid_live_rate_product(self) -> None:
+        result = validate_rates_response(
+            {
+                "ok": True,
+                "data": {
+                    "room_types": [
+                        {
+                            "name": "Standard King",
+                            "basic_room_image": "https://example.com/room.jpg",
+                            "products": [
+                                {
+                                    "cancellation_policy": {"type": "non_refundable"},
+                                    "rate": {
+                                        "rate_code": "R1",
+                                        "currency": "CNY",
+                                        "total_price": 800,
+                                        "per_night_price": 800,
+                                        "is_on_request": False,
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        )
+        self.assertTrue(result["valid"])
+        self.assertTrue(result["bookable"])
+        self.assertEqual(result["product_count"], 1)
+
+    def test_empty_live_rates_are_not_bookable(self) -> None:
+        result = validate_rates_response(
+            {"ok": True, "data": {"room_types": []}}
+        )
+        self.assertFalse(result["valid"])
+        self.assertFalse(result["bookable"])
+
+    def test_detail_without_image_requires_explicit_fallback(self) -> None:
+        result = validate_detail_response(
+            {
+                "ok": True,
+                "data": {
+                    "hotel": {
+                        "hotel_id": "H1",
+                        "name": "Example Hotel",
+                        "address": "Example Street",
+                    },
+                    "rooms": [],
+                },
+            }
+        )
+        self.assertTrue(result["valid"])
+        self.assertFalse(result["has_image"])
+        self.assertTrue(any("no hero-image" in warning for warning in result["warnings"]))
+
+    def test_booking_requires_nonempty_order_reference(self) -> None:
+        result = validate_booking_response(
+            {"ok": True, "data": {"agent_ref_id": "", "status": "UNPAID"}}
+        )
+        self.assertFalse(result["valid"])
+
+    def test_ambiguous_response_kind_is_not_guessed(self) -> None:
+        self.assertIsNone(
+            detect_kind({"ok": True, "data": {"hotels": [], "room_types": []}})
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- restructure the README around value, capabilities, client support, one-minute installation, prompts, workflow, security, product selection, and API support
- add Simplified Chinese, Japanese, and Spanish README translations with shared language navigation
- add Codex UI metadata in agents/openai.yaml
- publish the deterministic response validator and 13 standard-library tests
- run validation automatically on pull requests and main
- link all four TourMind hotel booking integrations

## Validation

- python3 -m unittest discover -s tests -v
- skill-creator quick_validate.py
- python3 -m py_compile scripts/validate_booking.py
- git diff --check

## Safety

The tests use simulated responses only. They do not read a Skill Token or call live booking, cancellation, or payment endpoints. The demo screenshot remains explicitly marked TODO.