### PR TITLE
docs: make skill installation client-neutral

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -22,26 +22,45 @@ Convierte cualquier agente de IA en un asistente integral de reservas de hotel: 
 
 | Cliente | Compatibilidad |
 |---|---|
-| OpenAI Codex | Compatible como Skill local instalado en `~/.codex/skills` |
+| WorkBuddy | Instala o importa este repositorio como Skill de usuario |
+| OpenAI Codex | Instala desde la interfaz de Skills o un directorio local compatible con tu versión |
+| Claude Code | Instala como Skill personal en `~/.claude/skills` |
 | Clientes compatibles con Agent Skills | Compatible cuando el cliente puede cargar un `SKILL.md` en la raíz y realizar solicitudes HTTPS `POST` |
 | Clientes de IA compatibles con MCP | Utiliza el paquete complementario [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) |
 
 ## Instalación en 1 minuto
 
-1. Clona el Skill en Codex:
+1. Genera un Skill Token en [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token).
 
-   ```bash
-   mkdir -p ~/.codex/skills
-   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git ~/.codex/skills/tourmind-booking
+2. En la interfaz de Skills de tu cliente de IA, instala o importa este repositorio de GitHub:
+
+   ```text
+   https://github.com/tourmind-com/Tourmind-Booking-Skill.git
    ```
 
-2. Genera un Skill Token en [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token), guarda el token sin modificar como `~/.codex/skills/tourmind-booking/skill_token.txt` y restringe el acceso:
+   Si el cliente carga Skills desde el sistema de archivos, clona el repositorio en su directorio de Skills personales:
 
    ```bash
-   chmod 600 ~/.codex/skills/tourmind-booking/skill_token.txt
+   CLIENT_SKILLS_DIR="<directorio-de-skills-del-cliente>"
+   mkdir -p "$CLIENT_SKILLS_DIR"
+   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git "$CLIENT_SKILLS_DIR/tourmind-booking"
    ```
 
-3. Reinicia el cliente de IA y solicita un hotel. No se necesita un servidor MCP local; este Skill llama directamente a la API de TourMind mediante HTTPS.
+   Directorios personales habituales:
+
+   | Cliente | Directorio |
+   |---|---|
+   | WorkBuddy | `~/.workbuddy/skills` |
+   | OpenAI Codex | Usa la interfaz de Skills o el directorio local compatible con tu versión de Codex |
+   | Claude Code | `~/.claude/skills` |
+
+3. En la carpeta `tourmind-booking` instalada, crea `skill_token.txt` y pega únicamente el Token original. En macOS o Linux, restringe el acceso:
+
+   ```bash
+   chmod 600 skill_token.txt
+   ```
+
+Recarga los Skills o reinicia el cliente de IA y solicita un hotel. No se necesita un servidor MCP local; este Skill llama directamente a la API de TourMind mediante HTTPS.
 
 Nunca confirmes `skill_token.txt` en Git. El archivo está excluido por `.gitignore`.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,26 +22,45 @@
 
 | クライアント | 対応方法 |
 |---|---|
-| OpenAI Codex | `~/.codex/skills` にローカル Skill としてインストール |
+| WorkBuddy | このリポジトリをユーザー Skill としてインストールまたはインポート |
+| OpenAI Codex | Skills 画面、または現在のバージョンが対応するローカル Skill ディレクトリからインストール |
+| Claude Code | `~/.claude/skills` に個人 Skill としてインストール |
 | Agent Skills 互換クライアント | ルートの `SKILL.md` を読み込み、HTTPS `POST` リクエストを送信できる場合に利用可能 |
 | MCP 対応 AI クライアント | 付属の [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) パッケージを使用 |
 
 ## 1分でインストール
 
-1. Skill を Codex にクローンします。
+1. [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token) で Skill Token を生成します。
 
-   ```bash
-   mkdir -p ~/.codex/skills
-   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git ~/.codex/skills/tourmind-booking
+2. AI クライアントの Skills 画面で、次の GitHub リポジトリをインストールまたはインポートします。
+
+   ```text
+   https://github.com/tourmind-com/Tourmind-Booking-Skill.git
    ```
 
-2. [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token) で Skill Token を生成し、トークン本体を `~/.codex/skills/tourmind-booking/skill_token.txt` に保存して、アクセス権を制限します。
+   クライアントがファイルシステムから Skill を読み込む場合は、個人 Skill ディレクトリにリポジトリをクローンします。
 
    ```bash
-   chmod 600 ~/.codex/skills/tourmind-booking/skill_token.txt
+   CLIENT_SKILLS_DIR="<クライアントのSkillディレクトリ>"
+   mkdir -p "$CLIENT_SKILLS_DIR"
+   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git "$CLIENT_SKILLS_DIR/tourmind-booking"
    ```
 
-3. AI クライアントを再起動し、ホテルを依頼します。ローカル MCP サーバーは不要で、この Skill は HTTPS で TourMind API を直接呼び出します。
+   一般的な個人 Skill ディレクトリ：
+
+   | クライアント | ディレクトリ |
+   |---|---|
+   | WorkBuddy | `~/.workbuddy/skills` |
+   | OpenAI Codex | Skills 画面、または現在の Codex バージョンが対応するローカルディレクトリを使用 |
+   | Claude Code | `~/.claude/skills` |
+
+3. インストールした `tourmind-booking` フォルダ内に `skill_token.txt` を作成し、Token 本体だけを貼り付けます。macOS または Linux ではアクセス権を制限します。
+
+   ```bash
+   chmod 600 skill_token.txt
+   ```
+
+Skills を再読み込みするか AI クライアントを再起動して、ホテルを依頼します。ローカル MCP サーバーは不要で、この Skill は HTTPS で TourMind API を直接呼び出します。
 
 `skill_token.txt` は絶対にコミットしないでください。このファイルは `.gitignore` で除外されています。
 

--- a/README.md
+++ b/README.md
@@ -22,26 +22,45 @@ Turn any AI agent into an end-to-end hotel booking assistant—search global inv
 
 | Client | Support |
 |---|---|
-| OpenAI Codex | Supported as a local Skill installed under `~/.codex/skills` |
+| WorkBuddy | Install or import this repository as a user Skill |
+| OpenAI Codex | Install from the Skills interface or a supported local skills directory |
+| Claude Code | Install as a personal Skill under `~/.claude/skills` |
 | Agent Skills-compatible clients | Compatible when the client can load a root `SKILL.md` and make outbound HTTPS `POST` requests |
 | MCP-capable AI clients | Use the companion [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) package |
 
 ## Install in 1 minute
 
-1. Clone the Skill into Codex:
+1. Generate a Skill Token at [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token).
 
-   ```bash
-   mkdir -p ~/.codex/skills
-   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git ~/.codex/skills/tourmind-booking
+2. In your AI client's Skills interface, install or import this GitHub repository:
+
+   ```text
+   https://github.com/tourmind-com/Tourmind-Booking-Skill.git
    ```
 
-2. Generate a Skill Token at [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token), save the raw token as `~/.codex/skills/tourmind-booking/skill_token.txt`, and restrict access:
+   If your client installs Skills from the filesystem, clone the repository into its personal skills directory:
 
    ```bash
-   chmod 600 ~/.codex/skills/tourmind-booking/skill_token.txt
+   CLIENT_SKILLS_DIR="<your-client-skills-directory>"
+   mkdir -p "$CLIENT_SKILLS_DIR"
+   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git "$CLIENT_SKILLS_DIR/tourmind-booking"
    ```
 
-3. Restart the AI client and ask for a hotel. No local MCP server is required; this Skill calls the TourMind API directly over HTTPS.
+   Common personal Skill locations:
+
+   | Client | Directory |
+   |---|---|
+   | WorkBuddy | `~/.workbuddy/skills` |
+   | OpenAI Codex | Use the Skills interface or the local directory supported by your Codex version |
+   | Claude Code | `~/.claude/skills` |
+
+3. In the installed `tourmind-booking` folder, create `skill_token.txt` and paste only the raw Token into it. On macOS or Linux, restrict access:
+
+   ```bash
+   chmod 600 skill_token.txt
+   ```
+
+Reload Skills or restart the AI client, then ask for a hotel. No local MCP server is required; this Skill calls the TourMind API directly over HTTPS.
 
 Never commit `skill_token.txt`. It is excluded by `.gitignore`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,26 +22,45 @@
 
 | 客户端 | 支持方式 |
 |---|---|
-| OpenAI Codex | 作为本地 Skill 安装到 `~/.codex/skills` |
+| WorkBuddy | 将本仓库安装或导入为用户 Skill |
+| OpenAI Codex | 通过 Skills 界面或当前版本支持的本地 Skill 目录安装 |
+| Claude Code | 作为个人 Skill 安装到 `~/.claude/skills` |
 | 兼容 Agent Skills 的客户端 | 客户端能够加载根目录 `SKILL.md` 并发起 HTTPS `POST` 请求时可用 |
 | 支持 MCP 的 AI 客户端 | 使用配套的 [TourMind Booking MCP](https://github.com/tourmind-com/Tourmind-Booking-MCP) |
 
 ## 1 分钟安装
 
-1. 将 Skill 克隆到 Codex：
+1. 前往 [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token) 生成 Skill Token。
 
-   ```bash
-   mkdir -p ~/.codex/skills
-   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git ~/.codex/skills/tourmind-booking
+2. 在你的 AI 客户端 Skills 界面中，安装或导入这个 GitHub 仓库：
+
+   ```text
+   https://github.com/tourmind-com/Tourmind-Booking-Skill.git
    ```
 
-2. 前往 [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token) 生成 Skill Token，将原始 Token 保存为 `~/.codex/skills/tourmind-booking/skill_token.txt`，然后限制文件权限：
+   如果客户端从本地目录加载 Skill，将仓库克隆到它的个人 Skill 目录：
 
    ```bash
-   chmod 600 ~/.codex/skills/tourmind-booking/skill_token.txt
+   CLIENT_SKILLS_DIR="<你的客户端 Skill 目录>"
+   mkdir -p "$CLIENT_SKILLS_DIR"
+   git clone https://github.com/tourmind-com/Tourmind-Booking-Skill.git "$CLIENT_SKILLS_DIR/tourmind-booking"
    ```
 
-3. 重启 AI 客户端并提出酒店需求。无需在本地运行 MCP 服务，本 Skill 会通过 HTTPS 直接调用 TourMind API。
+   常见的个人 Skill 目录：
+
+   | 客户端 | 目录 |
+   |---|---|
+   | WorkBuddy | `~/.workbuddy/skills` |
+   | OpenAI Codex | 使用 Skills 界面，或使用当前 Codex 版本支持的本地目录 |
+   | Claude Code | `~/.claude/skills` |
+
+3. 在安装后的 `tourmind-booking` 目录中新建 `skill_token.txt`，文件内只粘贴原始 Token。在 macOS 或 Linux 上限制文件权限：
+
+   ```bash
+   chmod 600 skill_token.txt
+   ```
+
+重新加载 Skills 或重启 AI 客户端，然后提出酒店需求。无需在本地运行 MCP 服务，本 Skill 会通过 HTTPS 直接调用 TourMind API。
 
 切勿提交 `skill_token.txt`；该文件已经被 `.gitignore` 排除。
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -60,6 +60,16 @@ class RepositoryContractTests(unittest.TestCase):
                 for repository in REPOSITORIES:
                     self.assertIn(repository, text)
 
+    def test_installation_is_client_neutral(self) -> None:
+        for readme in READMES:
+            with self.subTest(readme=readme.name):
+                text = readme.read_text(encoding="utf-8")
+                self.assertIn("WorkBuddy", text)
+                self.assertIn("OpenAI Codex", text)
+                self.assertIn("Claude Code", text)
+                self.assertIn("CLIENT_SKILLS_DIR", text)
+                self.assertNotIn("~/.codex/skills/tourmind-booking", text)
+
     def test_openai_interface_metadata(self) -> None:
         metadata = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
         self.assertIn('display_name: "TourMind Hotel Booking"', metadata)


### PR DESCRIPTION
Updates all four README languages so the one-minute setup works across WorkBuddy, Codex, Claude Code, and other Agent Skills-compatible clients. Adds a regression test that prevents the installation guide from becoming Codex-only again.