### PR TITLE
Center and resize README demo GIFs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -8,15 +8,27 @@ Convierte cualquier agente de IA en un asistente integral de reservas de hotel: 
 
 ### 1. Buscar hoteles en tiempo real
 
-![Demostración de búsqueda de hoteles con TourMind](docs/assets/demo/search-en.gif)
+<div align="center">
+  <a href="docs/assets/demo/search-en.gif">
+    <img src="docs/assets/demo/search-en.gif" alt="Demostración de búsqueda de hoteles con TourMind" width="720" />
+  </a>
+</div>
 
 ### 2. Comparar habitaciones reales
 
-![Demostración de habitaciones con TourMind](docs/assets/demo/detail-en.gif)
+<div align="center">
+  <a href="docs/assets/demo/detail-en.gif">
+    <img src="docs/assets/demo/detail-en.gif" alt="Demostración de habitaciones con TourMind" width="720" />
+  </a>
+</div>
 
 ### 3. Verificar la tarifa final y pagar
 
-![Demostración de verificación y pago con TourMind](docs/assets/demo/pay-en.gif)
+<div align="center">
+  <a href="docs/assets/demo/pay-en.gif">
+    <img src="docs/assets/demo/pay-en.gif" alt="Demostración de verificación y pago con TourMind" width="720" />
+  </a>
+</div>
 
 ## Capacidades principales
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,15 +8,27 @@
 
 ### 1. リアルタイムでホテルを検索
 
-![TourMind ホテル検索デモ](docs/assets/demo/search-en.gif)
+<div align="center">
+  <a href="docs/assets/demo/search-en.gif">
+    <img src="docs/assets/demo/search-en.gif" alt="TourMind ホテル検索デモ" width="720" />
+  </a>
+</div>
 
 ### 2. 実際の客室を比較
 
-![TourMind 客室詳細デモ](docs/assets/demo/detail-en.gif)
+<div align="center">
+  <a href="docs/assets/demo/detail-en.gif">
+    <img src="docs/assets/demo/detail-en.gif" alt="TourMind 客室詳細デモ" width="720" />
+  </a>
+</div>
 
 ### 3. 最終料金を確認して決済
 
-![TourMind 料金確認・決済デモ](docs/assets/demo/pay-en.gif)
+<div align="center">
+  <a href="docs/assets/demo/pay-en.gif">
+    <img src="docs/assets/demo/pay-en.gif" alt="TourMind 料金確認・決済デモ" width="720" />
+  </a>
+</div>
 
 ## 主な機能
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,27 @@ Turn any AI agent into an end-to-end hotel booking assistant—search global inv
 
 ### 1. Search live hotels
 
-![TourMind hotel search demo](docs/assets/demo/search-en.gif)
+<div align="center">
+  <a href="docs/assets/demo/search-en.gif">
+    <img src="docs/assets/demo/search-en.gif" alt="TourMind hotel search demo" width="720" />
+  </a>
+</div>
 
 ### 2. Compare real room options
 
-![TourMind room detail demo](docs/assets/demo/detail-en.gif)
+<div align="center">
+  <a href="docs/assets/demo/detail-en.gif">
+    <img src="docs/assets/demo/detail-en.gif" alt="TourMind room detail demo" width="720" />
+  </a>
+</div>
 
 ### 3. Verify the final rate and pay
 
-![TourMind rate verification and payment demo](docs/assets/demo/pay-en.gif)
+<div align="center">
+  <a href="docs/assets/demo/pay-en.gif">
+    <img src="docs/assets/demo/pay-en.gif" alt="TourMind rate verification and payment demo" width="720" />
+  </a>
+</div>
 
 ## Core capabilities
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -25,6 +25,8 @@ DEMO_ASSETS = (
     ROOT / "docs" / "assets" / "demo" / "detail-en.gif",
     ROOT / "docs" / "assets" / "demo" / "pay-en.gif",
 )
+DEMO_READMES = (READMES[0], READMES[2], READMES[3])
+DEMO_DISPLAY_WIDTH = 720
 
 
 class RepositoryContractTests(unittest.TestCase):
@@ -82,8 +84,24 @@ class RepositoryContractTests(unittest.TestCase):
                 self.assertGreater(asset.stat().st_size, 0)
                 self.assertLessEqual(asset.stat().st_size, 8_000_000)
                 relative_path = asset.relative_to(ROOT).as_posix()
-                for readme in (READMES[0], READMES[2], READMES[3]):
+                for readme in DEMO_READMES:
                     self.assertIn(relative_path, readme.read_text(encoding="utf-8"))
+
+    def test_english_demos_are_centered_and_resized(self) -> None:
+        for readme in DEMO_READMES:
+            text = readme.read_text(encoding="utf-8")
+            with self.subTest(readme=readme.name):
+                self.assertEqual(text.count('<div align="center">'), 3)
+                for asset in DEMO_ASSETS:
+                    relative_path = re.escape(asset.relative_to(ROOT).as_posix())
+                    self.assertRegex(
+                        text,
+                        rf'(?s)<div align="center">\s*'
+                        rf'<a href="{relative_path}">\s*'
+                        rf'<img src="{relative_path}" alt="[^"]+" '
+                        rf'width="{DEMO_DISPLAY_WIDTH}"\s*/>\s*'
+                        rf'</a>\s*</div>',
+                    )
 
     def test_openai_interface_metadata(self) -> None:
         metadata = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- center all three demo GIFs in the English, Japanese, and Spanish READMEs
- constrain display width to 720px while preserving responsive GitHub rendering
- keep each GIF clickable so readers can open the original asset
- add repository contract coverage for layout and sizing

## Validation
- `python3 -m unittest discover -s tests -v`
- `quick_validate.py .`
- `git diff --check`