### PR TITLE
Add demos to the Chinese README

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,9 +4,31 @@
 
 让任何 AI Agent 在一次对话中获得端到端酒店预订能力：搜索全球酒店资源、比较主流 OTA 与酒店供应商的实时价格、核验库存，并通过 TourMind 完成预订、支付、取消和订单管理。
 
-## 示例截图
+## 演示
 
-> **待补充：** 增加一张真实的端到端截图或短 GIF，展示酒店搜索、实时房价、最终库存验价和预订流程。
+### 1. 搜索实时酒店
+
+<div align="center">
+  <a href="docs/assets/demo/search-en.gif">
+    <img src="docs/assets/demo/search-en.gif" alt="TourMind 酒店搜索演示" width="720" />
+  </a>
+</div>
+
+### 2. 对比真实房型
+
+<div align="center">
+  <a href="docs/assets/demo/detail-en.gif">
+    <img src="docs/assets/demo/detail-en.gif" alt="TourMind 酒店房型详情演示" width="720" />
+  </a>
+</div>
+
+### 3. 核验最终价格并支付
+
+<div align="center">
+  <a href="docs/assets/demo/pay-en.gif">
+    <img src="docs/assets/demo/pay-en.gif" alt="TourMind 验价与支付演示" width="720" />
+  </a>
+</div>
 
 ## 核心能力
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -25,7 +25,7 @@ DEMO_ASSETS = (
     ROOT / "docs" / "assets" / "demo" / "detail-en.gif",
     ROOT / "docs" / "assets" / "demo" / "pay-en.gif",
 )
-DEMO_READMES = (READMES[0], READMES[2], READMES[3])
+DEMO_READMES = READMES
 DEMO_DISPLAY_WIDTH = 720
 DEMO_MAX_ASSET_BYTES = 4_000_000
 DEMO_MAX_TOTAL_BYTES = 10_500_000
@@ -79,7 +79,7 @@ class RepositoryContractTests(unittest.TestCase):
                 self.assertIn("CLIENT_SKILLS_DIR", text)
                 self.assertNotIn("~/.codex/skills/tourmind-booking", text)
 
-    def test_english_demo_assets_exist_and_are_linked(self) -> None:
+    def test_demo_assets_exist_and_are_linked(self) -> None:
         for asset in DEMO_ASSETS:
             with self.subTest(asset=asset.name):
                 self.assertTrue(asset.is_file())
@@ -93,7 +93,7 @@ class RepositoryContractTests(unittest.TestCase):
             DEMO_MAX_TOTAL_BYTES,
         )
 
-    def test_english_demos_are_centered_and_resized(self) -> None:
+    def test_demos_are_centered_and_resized(self) -> None:
         for readme in DEMO_READMES:
             text = readme.read_text(encoding="utf-8")
             with self.subTest(readme=readme.name):


### PR DESCRIPTION
## Summary
- replace the Chinese README demo placeholder with the shared search, detail, and payment GIFs
- use the same centered 720px, clickable layout as the other languages
- extend repository contract tests to require demos in all four localized READMEs

## Validation
- `python3 -m unittest discover -s tests -v`
- `quick_validate.py .`
- `git diff --check`