### PR TITLE
Redesign the README product header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,44 @@
-# TourMind Booking Skill
+<div align="center">
 
-[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md)
+<h1 style="border-bottom: none">
+  <b><a href="https://tourmind.com/skill">TourMind Booking Skills</a></b><br />
+  <strong>Let Your Agent Book Hotels Worldwide</strong>
+</h1>
+
+<!-- Hero image placeholder: add the final TourMind Booking Skills artwork here. -->
+
+<br />
+
+<p align="center">
+  Bring Your Customers Into Intelligent Travel
+</p>
+
+<br />
+
+<div align="center">
+  <a href="https://tourmind.com/skill">Product Page</a> |
+  <span>Live Demo</span> |
+  <a href="https://tourmind.com">Company</a>
+</div>
+
+<br />
+
+[![ClawHub installs](https://img.shields.io/badge/ClawHub_installs-1.4k-F97316)](https://clawhub.ai/tourmind/skills/tourmind-booking)
+[![Release](https://img.shields.io/github/v/release/tourmind-com/Tourmind-Booking-Skills?label=release)](https://github.com/tourmind-com/Tourmind-Booking-Skills/releases/latest)
+[![License](https://img.shields.io/github/license/tourmind-com/Tourmind-Booking-Skills)](LICENSE)
+
+</div>
+
+<br />
+
+<div align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.es.md">Español</a>
+</div>
+
+<br />
 
 Turn any AI agent into an end-to-end hotel booking assistant—search global inventory, compare live rates across leading OTAs and hotel suppliers, verify availability, and complete booking, payment, cancellation, and order management in one conversation with TourMind.
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -65,9 +65,24 @@ class RepositoryContractTests(unittest.TestCase):
             with self.subTest(readme=readme.name):
                 text = readme.read_text(encoding="utf-8")
                 for link in expected_links:
-                    self.assertIn(f"]({link})", text)
+                    self.assertTrue(
+                        f"]({link})" in text or f'href="{link}"' in text,
+                        f"{readme.name} must link to {link}",
+                    )
                 for repository in REPOSITORIES:
                     self.assertIn(repository, text)
+
+    def test_english_readme_marketing_header(self) -> None:
+        text = READMES[0].read_text(encoding="utf-8")
+        self.assertIn("TourMind Booking Skills", text)
+        self.assertIn("Let Your Agent Book Hotels Worldwide", text)
+        self.assertIn("Bring Your Customers Into Intelligent Travel", text)
+        self.assertIn('href="https://tourmind.com/skill">Product Page</a>', text)
+        self.assertIn("<span>Live Demo</span>", text)
+        self.assertIn('href="https://tourmind.com">Company</a>', text)
+        self.assertIn("ClawHub_installs-1.4k", text)
+        self.assertIn("github/v/release/tourmind-com/Tourmind-Booking-Skills", text)
+        self.assertIn("github/license/tourmind-com/Tourmind-Booking-Skills", text)
 
     def test_installation_is_client_neutral(self) -> None:
         for readme in READMES:
@@ -97,7 +112,6 @@ class RepositoryContractTests(unittest.TestCase):
         for readme in DEMO_READMES:
             text = readme.read_text(encoding="utf-8")
             with self.subTest(readme=readme.name):
-                self.assertEqual(text.count('<div align="center">'), 3)
                 for asset in DEMO_ASSETS:
                     relative_path = re.escape(asset.relative_to(ROOT).as_posix())
                     self.assertRegex(


### PR DESCRIPTION
## Summary
- redesign the English README header using the AFFiNE hierarchy as a reference
- add the linked TourMind Booking Skills product name, slogan, subtitle, and centered navigation
- reserve the hero-image position without rendering a placeholder
- add ClawHub installs, latest release, and MIT license badges
- keep Live Demo visible but non-clickable until its URL is ready
- center the language switcher and add repository contract coverage

## Validation
- `python3 -m unittest discover -s tests -v`
- `quick_validate.py .`
- `git diff --check`
- verified every active header link and badge endpoint returns HTTP 200