### PR TITLE
Fix the ClawHub badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 <br />
 
-[![ClawHub installs](https://img.shields.io/badge/ClawHub_installs-1.4k-F97316)](https://clawhub.ai/tourmind/skills/tourmind-booking)
+[![ClawHub installs](https://img.shields.io/badge/ClawHub_installs-1.4k-F97316)](https://clawhub.ai/tourmind/skills/hotel-booking-ai)
 [![Release](https://img.shields.io/github/v/release/tourmind-com/Tourmind-Booking-Skills?label=release)](https://github.com/tourmind-com/Tourmind-Booking-Skills/releases/latest)
 [![License](https://img.shields.io/github/license/tourmind-com/Tourmind-Booking-Skills)](LICENSE)
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -83,6 +83,9 @@ class RepositoryContractTests(unittest.TestCase):
         self.assertIn("<span>Live Demo</span>", text)
         self.assertIn('href="https://tourmind.com">Company</a>', text)
         self.assertIn("ClawHub_installs-1.4k", text)
+        self.assertIn(
+            "](https://clawhub.ai/tourmind/skills/hotel-booking-ai)", text
+        )
         self.assertIn("github/v/release/tourmind-com/Tourmind-Booking-Skills", text)
         self.assertIn("github/license/tourmind-com/Tourmind-Booking-Skills", text)
         self.assertTrue(HERO_ASSET.is_file())


### PR DESCRIPTION
## Summary
- point the ClawHub installs badge to the correct `hotel-booking-ai` listing
- add a repository contract assertion for the full ClawHub URL

## Validation
- new ClawHub URL returns HTTP 200
- `python3 -m unittest discover -s tests -v`
- `quick_validate.py .`
- `git diff --check`