### PR TITLE
Update the TourMind Skills product URL

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -159,7 +159,7 @@ El valor almacenado en caché `search_hotels.min_price` es únicamente una seña
 
 - Campos y contratos de respuesta: [references/parameter_guide.md](references/parameter_guide.md)
 - Skill Token: [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token)
-- Página del producto: [tourmind.com/skill](https://tourmind.com/skill)
+- Página del producto: [tourmind.com/skills](https://tourmind.com/skills)
 - Soporte en GitHub: [abrir una incidencia](https://github.com/tourmind-com/Tourmind-Booking-Skills/issues)
 - Consultas sobre hoteles: `hotel@tourmind.com`
 - Colaboración comercial: `bp@tourmind.com`

--- a/README.ja.md
+++ b/README.ja.md
@@ -159,7 +159,7 @@ Skills を再読み込みするか AI クライアントを再起動して、ホ
 
 - リクエスト項目とレスポンス契約：[references/parameter_guide.md](references/parameter_guide.md)
 - Skill Token：[tourmind.com/user/skill-token](https://tourmind.com/user/skill-token)
-- 製品ページ：[tourmind.com/skill](https://tourmind.com/skill)
+- 製品ページ：[tourmind.com/skills](https://tourmind.com/skills)
 - GitHub サポート：[Issue を作成](https://github.com/tourmind-com/Tourmind-Booking-Skills/issues)
 - ホテル事業に関するお問い合わせ：`hotel@tourmind.com`
 - ビジネス提携：`bp@tourmind.com`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <h1 style="border-bottom: none">
-  <b><a href="https://tourmind.com/skill">TourMind Booking Skills</a></b><br />
+  <b><a href="https://tourmind.com/skills">TourMind Booking Skills</a></b><br />
   <strong>Let Your Agent Book Hotels Worldwide</strong>
 </h1>
 
@@ -18,7 +18,7 @@
 <br />
 
 <div align="center">
-  <a href="https://tourmind.com/skill">Product Page</a> |
+  <a href="https://tourmind.com/skills">Product Page</a> |
   <span>Live Demo</span> |
   <a href="https://tourmind.com">Company</a>
 </div>
@@ -199,7 +199,7 @@ Cached `search_hotels.min_price` is only a candidate signal. User-visible prices
 
 - Request fields and response contracts: [references/parameter_guide.md](references/parameter_guide.md)
 - Skill Token: [tourmind.com/user/skill-token](https://tourmind.com/user/skill-token)
-- Product page: [tourmind.com/skill](https://tourmind.com/skill)
+- Product page: [tourmind.com/skills](https://tourmind.com/skills)
 - GitHub support: [open an issue](https://github.com/tourmind-com/Tourmind-Booking-Skills/issues)
 - Hotel business inquiry: `hotel@tourmind.com`
 - Business cooperation: `bp@tourmind.com`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,7 +159,7 @@
 
 - 请求字段与响应契约：[references/parameter_guide.md](references/parameter_guide.md)
 - 获取 Skill Token：[tourmind.com/user/skill-token](https://tourmind.com/user/skill-token)
-- 产品页面：[tourmind.com/skill](https://tourmind.com/skill)
+- 产品页面：[tourmind.com/skills](https://tourmind.com/skills)
 - GitHub 支持：[提交 Issue](https://github.com/tourmind-com/Tourmind-Booking-Skills/issues)
 - 酒店业务咨询：`hotel@tourmind.com`
 - 商务合作：`bp@tourmind.com`

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -31,6 +31,7 @@ DEMO_MAX_ASSET_BYTES = 4_000_000
 DEMO_MAX_TOTAL_BYTES = 10_500_000
 HERO_ASSET = ROOT / "docs" / "assets" / "hero" / "tourmind-booking-skills.png"
 HERO_TARGET = "https://tourmind.com/en-US/user/skill-token"
+PRODUCT_PAGE_URL = "https://tourmind.com/skills"
 
 
 class RepositoryContractTests(unittest.TestCase):
@@ -73,13 +74,16 @@ class RepositoryContractTests(unittest.TestCase):
                     )
                 for repository in REPOSITORIES:
                     self.assertIn(repository, text)
+                self.assertIn(PRODUCT_PAGE_URL, text)
+                self.assertNotIn("https://tourmind.com/skill)", text)
+                self.assertNotIn('https://tourmind.com/skill"', text)
 
     def test_english_readme_marketing_header(self) -> None:
         text = READMES[0].read_text(encoding="utf-8")
         self.assertIn("TourMind Booking Skills", text)
         self.assertIn("Let Your Agent Book Hotels Worldwide", text)
         self.assertIn("Bring Your Customers Into Intelligent Travel", text)
-        self.assertIn('href="https://tourmind.com/skill">Product Page</a>', text)
+        self.assertIn(f'href="{PRODUCT_PAGE_URL}">Product Page</a>', text)
         self.assertIn("<span>Live Demo</span>", text)
         self.assertIn('href="https://tourmind.com">Company</a>', text)
         self.assertIn("ClawHub_installs-1.4k", text)


### PR DESCRIPTION
## Summary
- update the product page URL from `/skill` to `/skills` in all four localized READMEs
- update both product links in the English marketing header
- add repository contract coverage for the new URL and reject the previous URL

## Validation
- product URL returns HTTP 200
- `python3 -m unittest discover -s tests -v`
- `quick_validate.py .`
- `git diff --check`