### PR TITLE
feat: support room occupancy and batch rate queries

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -6,7 +6,7 @@ description: >
 
 # TourMind Booking Skill
 
-**Skill version:** `1.0.5`
+**Skill version:** `1.0.6`
 
 Use TourMind HTTP APIs for live hotel discovery, room-rate comparison, availability checks, booking, order management and payment.
 
@@ -58,7 +58,7 @@ Respond in the language used by the user's current request unless the user expli
 
 1. Use only TourMind API data for hotels, coordinates, rooms, images, prices, policies and availability. Never fill gaps from memory or training data.
 2. Before the first hotel-search API call, require a location, check-in date and check-out date. The scheduled update check does not require these fields. If adult count is omitted, use 1 adult per room and explicitly tell the user that the search assumes one guest; invite them to provide the guest count for multiple occupancy. Apply the safe defaults below instead of asking unnecessary questions.
-3. Treat `search_hotels.min_price` as a cached candidate signal only. Present a hotel as having a live rate product and quote a price only after `query_room_rates` returns a matching product. Describe inventory as immediately bookable only when that product has `is_on_request=false`.
+3. Treat `search_hotels.min_price` as a cached candidate signal only. Present a hotel as having a live rate product and quote a price only after `query_room_rates` or a successful `batch_query_room_rates` item returns a matching product. Describe inventory as immediately bookable only when that product has `is_on_request=false`.
 4. Respect explicit radius, budget, star, occupancy and facility requirements as hard constraints. Never silently expand a hard radius or budget.
 5. Before every `create_booking`, require the guest's full legal name and a valid `contact_email`. Email is mandatory in this skill even if the backend accepts an omitted value. Never offer a skip option, invent an email or reuse an unconfirmed email. Do not collect a phone number.
 6. Interpret cancellation policies exactly as returned. `non_refundable` or `effective_non_refundable=true` means non-refundable. `free_cancel_before_deadline` means free cancellation only through its deadline.
@@ -78,6 +78,7 @@ All endpoints use `POST` with JSON and require `token` from `{baseDir}/skill_tok
 | Search hotel candidates | `/skill/tob/search_hotels` |
 | Get hotel details and images | `/skill/tob/get_hotel_detail` |
 | Get live rooms and rates | `/skill/tob/query_room_rates` |
+| Get live rooms and rates for multiple hotels | `/skill/tob/batch_query_room_rates` |
 | Recheck rate and availability | `/skill/tob/check_room_availability` |
 | Create booking | `/skill/tob/create_booking` |
 | Query booking | `/skill/tob/query_booking` |
@@ -140,6 +141,7 @@ Do not ask for information that can be inferred safely. State every applied assu
 | Missing or vague input | Default behavior |
 |---|---|
 | `room_count` omitted | Use 1 room and disclose the assumed occupancy. If adult count is also omitted, use 1 adult for that room and tell the user: `I will search for 1 guest in 1 room; tell me if more people will stay.` Translate this message into the user's language. |
+| Children omitted | Use 0 children and an empty `children_ages` array. |
 | Date has no year | Use the next future occurrence in the user's timezone. Show the resolved `YYYY-MM-DD` dates. |
 | Relative date such as tonight or tomorrow | Resolve it to exact dates in the user's timezone. |
 | "Nearby" or "as close as possible" with no radius | Use 3 km and state that default. |
@@ -147,6 +149,8 @@ Do not ask for information that can be inferred safely. State every applied assu
 | Budget wording such as "under 2000" is ambiguous | Clarify whether it is per night or trip total before applying a hard filter. |
 
 Still ask when the location, check-in date or check-out date cannot be inferred. Never replace an adult count the user already provided. Ensure checkout is later than check-in and all dates sent to the API use `YYYY-MM-DD`.
+
+`adults`, `children`, and `children_ages` describe **each room**, while `room_count` repeats that same occupancy for all rooms. `children_ages` must contain one age from 0 through 17 for each child in one room. For example, `adults=2, room_count=2, children=1, children_ages=[8]` means two rooms, each with two adults and one eight-year-old child. If the user gives only total guests for multiple rooms, ask for the per-room occupancy before calling the API. Do not send `room_occupancies`; mixed per-room configurations are not supported.
 
 ## Location and POI resolution
 
@@ -195,7 +199,7 @@ Never invent coordinates, geocode from model memory or substitute a city-wide se
 
 ## Search, verify and select five
 
-`search_hotels` returns at most 20 candidates. Treat this as a candidate pool, not the final answer.
+Region and nearby `search_hotels` calls return at most 20 candidates that have already passed a live-rate availability probe for the requested dates and occupancy. Keyword mode remains a hotel-name lookup and does not perform that probe. Treat `min_price` as cached display data even for live-filtered candidates; use room-rate products for prices.
 
 1. Parse the user's requirements into:
    - **Hard constraints:** dates, occupancy, room count, explicit radius, strict budget, required star level, required facilities or property type.
@@ -203,8 +207,9 @@ Never invent coordinates, geocode from model memory or substitute a city-wide se
 2. Call `search_hotels` with the applicable hard search fields. Preserve the complete raw candidate pool and `distance_km` values so a later "show all" request can be fulfilled.
    - Preserve the top-level `web_url` and include it as a clickable read-only hotel-results link. Place the link guidance after the search-summary fields and before the first recommended hotel, with one blank line on each side. Tell the user to open a hotel detail page, click the copy button beside the desired room product, and send the copied product information back in the conversation so you can continue verification and booking. Do not expose the underlying token or alter the URL. The linked session only permits hotel lists, hotel details and room quotes; it does not permit verification, booking, payment, `/book/*`, order, finance or account-management pages.
 3. Exclude obvious hard-constraint failures from the recommendation/ranking pool, but retain them in the raw pool with every failed constraint recorded.
-4. Call `query_room_rates` for every remaining candidate needed to rank the recommendation pool fairly, in controlled batches. Do not stop at the first five cached-price results. Exclude candidates with no matching live product from recommendations, but retain their no-live-product status in the raw pool.
-   - Preserve each response's top-level `web_url` as that exact hotel's `hotel_web_url`. Never reuse the hotel-list `search_hotels.web_url` for an individual hotel.
+4. Call `batch_query_room_rates` once with the remaining candidate IDs needed to rank the recommendation pool fairly; each request accepts at most 20 hotels and the server owns the four-worker concurrency. Use `query_room_rates` when only one hotel needs rates. Do not create another client-side request pool. Exclude candidates with no matching live product from recommendations, but retain their no-live-product status in the raw pool.
+   - Read every batch item independently. A top-level successful batch may contain matched, empty, and failed hotel items; never discard successful items because another hotel failed.
+   - Preserve each successful batch item's `data.web_url`, or the single-hotel response's top-level `web_url`, as that exact hotel's `hotel_web_url`. Never reuse the hotel-list `search_hotels.web_url` for an individual hotel.
    - `is_on_request=false` is immediately bookable inventory.
    - `is_on_request=true` is a request product whose inventory still needs supplier confirmation. It does not satisfy an explicit "immediately bookable" or "real-time availability" hard requirement; otherwise keep it eligible but rank it after immediately bookable options and label it clearly.
 5. If a required or preferred facility cannot be verified from search data, call `get_hotel_detail` for the relevant candidates before ranking it.
@@ -319,7 +324,7 @@ End with a clear next action: the user can choose a room for final availability 
 0. Complete inputs and resolve location/POI
 1. search_location / keyword search as needed
 2. search_hotels for up to 20 candidates
-3. query_room_rates and rank verified candidates
+3. batch_query_room_rates (or query_room_rates for one hotel) and rank verified candidates
 4. Present five hotels with hero images and match reasons
 5. On hotel selection, return hotel detail + room images + live quotes
 6. check_room_availability for the chosen rate
@@ -373,7 +378,8 @@ Before cancellation, confirm the exact `agent_ref_id`. In availability cancellat
 ## Error and empty-result handling
 
 - Retry a transient network/server failure only when safe; if it still fails, quote the concrete error and stop.
-- For zero live rooms, distinguish `no candidate hotels` from `candidates found but no matching live room`.
+- Treat `reason=no_matching_live_room` as a successful business-empty result and suggest changing dates or occupancy.
+- Treat `hotel_not_found` as a missing or unavailable hotel, `upstream_timeout` as a temporary real-time pricing timeout, `upstream_error` or `hotel_detail_unavailable` as a service failure, and `invalid_request` as a request that must be corrected. Never describe timeout or service failure as no availability.
 - For fewer than five qualifying hotels, show the verified results and explain which hard constraint limited the list.
 - Offer, but never silently perform, changes to a hard radius, budget, dates or occupancy.
 - Never expose the Skill Token, internal payment codes or raw secrets in output.

--- a/SKILL.md
+++ b/SKILL.md
@@ -207,7 +207,7 @@ Region and nearby `search_hotels` calls return at most 20 candidates that have a
 2. Call `search_hotels` with the applicable hard search fields. Preserve the complete raw candidate pool and `distance_km` values so a later "show all" request can be fulfilled.
    - Preserve the top-level `web_url` and include it as a clickable read-only hotel-results link. Place the link guidance after the search-summary fields and before the first recommended hotel, with one blank line on each side. Tell the user to open a hotel detail page, click the copy button beside the desired room product, and send the copied product information back in the conversation so you can continue verification and booking. Do not expose the underlying token or alter the URL. The linked session only permits hotel lists, hotel details and room quotes; it does not permit verification, booking, payment, `/book/*`, order, finance or account-management pages.
 3. Exclude obvious hard-constraint failures from the recommendation/ranking pool, but retain them in the raw pool with every failed constraint recorded.
-4. Call `batch_query_room_rates` once with the remaining candidate IDs needed to rank the recommendation pool fairly; each request accepts at most 20 hotels and the server owns the four-worker concurrency. Use `query_room_rates` when only one hotel needs rates. Do not create another client-side request pool. Exclude candidates with no matching live product from recommendations, but retain their no-live-product status in the raw pool.
+4. Call `batch_query_room_rates` with the remaining candidate IDs needed to rank the recommendation pool fairly. Put at most 20 hotels in each request. When more than one batch is required, the client may run up to three `batch_query_room_rates` requests concurrently; never exceed three concurrent requests. The server still owns the four-worker concurrency within each batch. Use `query_room_rates` when only one hotel needs rates. Exclude candidates with no matching live product from recommendations, but retain their no-live-product status in the raw pool.
    - Read every batch item independently. A top-level successful batch may contain matched, empty, and failed hotel items; never discard successful items because another hotel failed.
    - Preserve each successful batch item's `data.web_url`, or the single-hotel response's top-level `web_url`, as that exact hotel's `hotel_web_url`. Never reuse the hotel-list `search_hotels.web_url` for an individual hotel.
    - `is_on_request=false` is immediately bookable inventory.
@@ -324,11 +324,11 @@ End with a clear next action: the user can choose a room for final availability 
 0. Complete inputs and resolve location/POI
 1. search_location / keyword search as needed
 2. search_hotels for up to 20 candidates
-3. batch_query_room_rates (or query_room_rates for one hotel) and rank verified candidates
+3. batch_query_room_rates in groups of up to 20 hotels, with at most 3 concurrent batch requests (or query_room_rates for one hotel), and rank verified candidates
 4. Present five hotels with hero images and match reasons
 5. On hotel selection, return hotel detail + room images + live quotes
 6. check_room_availability for the chosen rate
-7. Present the required final booking-confirmation template, including hotel check-in/out times, tax notice, explicit mandatory fees, customer-service contact and the latest checked price/policy
+7. Present the required final booking-confirmation template, including the complete per-room adult/child occupancy, children's ages, hotel check-in/out times, tax notice, explicit mandatory fees, customer-service contact and the latest checked price/policy
 8. Obtain the user's explicit confirmation plus full legal guest name and mandatory contact_email
 9. create_booking with the checked rate_code and checked total_price
 10. Return agent_ref_id and ask for Stripe, WeChat Pay, or Alipay
@@ -343,7 +343,7 @@ Before `create_booking`:
 - Require a plausible email format and confirm it belongs to the current booking context.
 - Use the `rate_code` and `total_price` returned by `check_room_availability`, not the earlier query price.
 
-For hotel check-in/out times, instructions and mandatory at-property fees, use the selected hotel's `get_hotel_detail` response. Show unavailable fields using the localized equivalent of `Not provided by the hotel` rather than guessing. If no explicit mandatory-fee content is returned, replace `{mandatory_fee_summary_or_fallback}` with the localized equivalent of `The hotel did not return any additional mandatory fee information.` Use the following English template as the canonical final-confirmation structure; translate all user-facing labels and guidance into the user's language while preserving the fields, values, Markdown structure, and confirmation semantics:
+For hotel check-in/out times, instructions and mandatory at-property fees, use the selected hotel's `get_hotel_detail` response. Show unavailable fields using the localized equivalent of `Not provided by the hotel` rather than guessing. If no explicit mandatory-fee content is returned, replace `{mandatory_fee_summary_or_fallback}` with the localized equivalent of `The hotel did not return any additional mandatory fee information.` Always render both occupancy rows in the template. When there are no children, show the localized equivalents of `0 children` and `Not applicable` rather than omitting the fields. Use the following English template as the canonical final-confirmation structure; translate all user-facing labels and guidance into the user's language while preserving the fields, values, Markdown structure, and confirmation semantics:
 
 ```markdown
 ### Please confirm your booking
@@ -355,7 +355,8 @@ For hotel check-in/out times, instructions and mandatory at-property fees, use t
 | Check-in date | {check_in_date} |
 | Check-out date | {check_out_date} |
 | Check-in / check-out time | Check-in from {checkin_begin_time_or_not_provided}; check-out by {checkout_time_or_not_provided} |
-| Guests | {guest_count} adults, {room_count} rooms |
+| Occupancy | {adults_per_room} adults and {children_per_room} children per room; {room_count} rooms |
+| Children's ages | {children_ages_per_room_or_not_applicable} per room |
 | Room price total | {checked_total_price} {currency} |
 | Cancellation policy | {checked_cancellation_policy} |
 | Availability | {checked_availability_status} |
@@ -378,6 +379,7 @@ Before cancellation, confirm the exact `agent_ref_id`. In availability cancellat
 ## Error and empty-result handling
 
 - Retry a transient network/server failure only when safe; if it still fails, quote the concrete error and stop.
+- The `reason` codes below apply to `query_room_rates` responses and to individual `batch_query_room_rates.data.results[]` items. For a batch, handle each item's `reason` independently; do not treat an item-level failure as a failure of the whole batch. `invalid_request` may also appear as a top-level error when the entire single-hotel or batch request is malformed.
 - Treat `reason=no_matching_live_room` as a successful business-empty result and suggest changing dates or occupancy.
 - Treat `hotel_not_found` as a missing or unavailable hotel, `upstream_timeout` as a temporary real-time pricing timeout, `upstream_error` or `hotel_detail_unavailable` as a service failure, and `invalid_request` as a request that must be corrected. Never describe timeout or service failure as no availability.
 - For fewer than five qualifying hotels, show the verified results and explain which hard constraint limited the list.

--- a/references/parameter_guide.md
+++ b/references/parameter_guide.md
@@ -286,7 +286,7 @@ Use this endpoint to query multiple candidate hotels under one shared stay and p
 | `children` | integer | no; per room |
 | `children_ages` | integer[] | no; one 0–17 age per child in one room |
 
-The server uses a fixed four-worker pool and preserves input order. Do not wrap this endpoint in another client-side concurrency pool. Top-level `ok=true` means the batch completed; inspect each item independently. Abbreviated response:
+Within each request, the server uses a fixed four-worker pool and preserves input order. A client may run up to three `batch_query_room_rates` requests concurrently when multiple batches are required; never exceed three concurrent requests. Each request still accepts at most 20 hotel IDs. Top-level `ok=true` means the batch completed; inspect each item independently. Abbreviated response:
 
 ```json
 {
@@ -301,7 +301,7 @@ The server uses a fixed four-worker pool and preserves input order. Do not wrap 
 }
 ```
 
-`matched` counts hotels with products, `empty` counts successful `no_matching_live_room` results, and `failed` counts per-hotel errors. Keep successful items when another item fails. Each successful item may include that hotel's read-only `web_url`.
+`matched` counts hotels with products, `empty` counts successful `no_matching_live_room` results, and `failed` counts per-hotel errors. The documented rate-query `reason` codes apply to each `data.results[]` item independently. Keep successful items when another item fails. Each successful item may include that hotel's read-only `web_url`.
 
 ### `POST /skill/tob/check_room_availability`
 
@@ -353,7 +353,7 @@ There is no custom return URL. Return `pay_url` to the user. For Stripe, also sh
 Use all candidates needed for a fair top-five choice; do not merely display the first five cached-price rows.
 
 1. Preserve the complete original `search_hotels` candidate pool. Exclude search-level hard failures, including explicit radius and star constraints, only from the recommendation pool; record all failed hard constraints on the original candidate.
-2. Call `batch_query_room_rates` once for the remaining candidates, with at most 20 hotel IDs. Process each item independently and retain partial successes.
+2. Split the remaining candidates into batches of at most 20 hotel IDs and call `batch_query_room_rates`. Run one request when one batch is sufficient; when multiple batches are required, run no more than three requests concurrently. Process each item independently and retain partial successes.
 3. Filter products by occupancy, room count, strict budget, requested room/meal and other hard fields.
 4. Drop candidates with no matching live product only from the recommendation pool; retain their identifiers and `no matching live product` status in the original pool.
 5. Treat `is_on_request=true` as supplier-confirmation inventory, not immediate availability. Exclude it when the user explicitly requires immediately bookable or real-time available inventory; otherwise rank it after `is_on_request=false` and use the localized label equivalent of `Inventory requires supplier confirmation`.
@@ -427,7 +427,7 @@ Guest names should match identification documents. The service handles Chinese a
 Before booking, confirm:
 
 - exact hotel and room product;
-- dates, occupancy and room count;
+- dates, adults per room, children per room, every child's age per room, and room count;
 - latest checked total/currency, cancellation policy and availability;
 - hotel `checkin.begin_time` and `checkout.time`, or the localized equivalent of `Not provided by the hotel` if either field is absent;
 - explicit `hotel.fees.mandatory` content, or the localized equivalent of `The hotel did not return any additional mandatory fee information.`;
@@ -449,6 +449,8 @@ Common order statuses:
 
 ## Errors and performance
 
+The `reason` codes in the table below apply to `query_room_rates` responses and individual `batch_query_room_rates.data.results[]` items. Process batch item reasons independently; an item-level error does not make the whole batch unsuccessful. `invalid_request` may also be returned as a top-level error when the entire single-hotel or batch request is malformed.
+
 | Error/symptom | Required handling |
 |---|---|
 | `unauthorized` / HTTP 401 | Delete the token file, display the required sign-in/token/registration guidance from `SKILL.md`, and request a replacement token |
@@ -464,4 +466,4 @@ Common order statuses:
 | Rate check failed | Re-run availability once for the selected rate; if still failed, report it |
 | Booking creation failed | Report the error; do not retry with guessed guest/order data |
 
-Use `batch_query_room_rates` for multi-hotel rate retrieval, with at most 20 hotels per request. Keep booking, cancellation and payment operations sequential and explicitly confirmed.
+Use `batch_query_room_rates` for multi-hotel rate retrieval, with at most 20 hotels per request and at most three concurrent batch requests per client. Keep booking, cancellation and payment operations sequential and explicitly confirmed.

--- a/references/parameter_guide.md
+++ b/references/parameter_guide.md
@@ -61,7 +61,7 @@ No-update response:
   "skill_update": {
     "available": false,
     "display_to_user": false,
-    "latest_version": "1.0.5"
+    "latest_version": "1.0.6"
   }
 }
 ```
@@ -94,6 +94,8 @@ An update-check failure is advisory: continue the hotel workflow, do not repeate
 - If `adults` is also omitted, default to 1 adult per room. Tell the user that the search uses 1 guest in 1 room and invite them to provide the guest count if multiple people will stay. Translate this notice into the user's language.
 - Preserve any adult count the user already provided; never replace it with the default.
 - `adults` means adults per room, not the total across all rooms.
+- `children` and `children_ages` also describe one room. The age array length must equal `children`, and every age must be from 0 through 17.
+- `room_count` repeats the same adult/child configuration for every room. Ask for the per-room occupancy when the user gives only totals for multiple rooms. Do not send `room_occupancies`; mixed configurations are unsupported.
 - Do not call live-rate endpoints until location, check-in and check-out are known. Supply the default adult count when the user omitted it.
 
 Currency values use ISO 4217 codes such as `CNY`, `USD`, `EUR`, `GBP` or `JPY`. Display the currency returned by the API; do not silently relabel it.
@@ -178,11 +180,13 @@ Priced-search fields:
 | `check_out_date` | string | yes | `YYYY-MM-DD` |
 | `adults` | integer | yes | Adults per room |
 | `room_count` | integer | no | Default 1 |
+| `children` | integer | no | Children per room; default 0 |
+| `children_ages` | integer[] | no | One age from 0–17 for each child in one room |
 | `lowest_price` | number | no | Candidate lower bound in CNY |
 | `highest_price` | number | no | Candidate upper bound in CNY |
 | `location_name` | string | priced searches | Resolved region or Google place name used to describe the result page |
 
-The endpoint returns at most 20 hotels. Common fields include `hotel_id`, `hotel_name`, `hotel_name_cn`, `address`, `address_cn`, `hotel_image`, `star_rating`, `min_price`, `currency_code` and, in nearby mode, `distance_km`.
+The endpoint returns at most 20 hotels. In region and nearby modes, the backend probes live rates with the same dates and occupancy and returns only hotels with at least one available rate. Keyword mode does not run this probe. Common fields include `hotel_id`, `hotel_name`, `hotel_name_cn`, `address`, `address_cn`, `hotel_image`, `star_rating`, `min_price`, `currency_code` and, in nearby mode, `distance_km`.
 
 Priced searches also return `search_scope`, top-level `web_url`, `web_url_expires_at` and `web_url_one_time`. Include `web_url` in the user-facing response. The link can be opened repeatedly until `web_url_expires_at`; it establishes an authenticated TourMind session marked `accessMode=skill_readonly` without exposing the Skill token. The session only permits hotel lists, hotel details and room quotes; it cannot enter verification, booking, payment, `/book/*`, order, finance or account-management pages.
 
@@ -225,6 +229,8 @@ Request:
 | `check_out_date` | string | yes |
 | `adults` | integer | yes |
 | `room_count` | integer | no |
+| `children` | integer | no; children per room |
+| `children_ages` | integer[] | no; one 0–17 age per child in one room |
 
 `data.room_types[]` contains room-level names, bed description, optional `basic_room_image` and `products[]`.
 
@@ -263,9 +269,43 @@ Do not map numeric/string `meal_type` codes to breakfast, dinner or another meal
 
 The response also includes top-level `web_url`, `web_url_expires_at` and `web_url_one_time`. The link can be opened repeatedly until `web_url_expires_at`. The linked TourMind page displays the hotel and returned room quotes in read-only mode. Preserve it with that exact hotel and show it directly below the hotel's hero image using the localized label equivalent of `[View hotel details]`; preserve the exact URL, never show the original image URL as a separate link, and never substitute the hotel-list `search_hotels.web_url`. It does not support verification, booking, payment, `/book/*`, order management, finance or account management. Use the Skill APIs in the authenticated AI conversation for those actions. If the field is unexpectedly absent, omit the hotel-detail link rather than constructing one.
 
+An empty live result is HTTP 200 with `data.room_types=[]` and `data.reason=no_matching_live_room`. Do not treat it as a system failure.
+
+### `POST /skill/tob/batch_query_room_rates`
+
+Use this endpoint to query multiple candidate hotels under one shared stay and per-room occupancy configuration.
+
+| Field | Type | Required |
+|---|---|---|
+| `token` | string | yes |
+| `hotel_ids` | string[] | yes; 1–20 hotels |
+| `check_in_date` | string | yes |
+| `check_out_date` | string | yes |
+| `adults` | integer | yes; per room |
+| `room_count` | integer | no; default 1 |
+| `children` | integer | no; per room |
+| `children_ages` | integer[] | no; one 0–17 age per child in one room |
+
+The server uses a fixed four-worker pool and preserves input order. Do not wrap this endpoint in another client-side concurrency pool. Top-level `ok=true` means the batch completed; inspect each item independently. Abbreviated response:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "results": [
+      {"hotel_id": "23059757", "ok": true, "data": {"total": 1}},
+      {"hotel_id": "999999999", "ok": false, "reason": "hotel_not_found", "error": "hotel not found"}
+    ],
+    "summary": {"total": 2, "matched": 1, "empty": 0, "failed": 1}
+  }
+}
+```
+
+`matched` counts hotels with products, `empty` counts successful `no_matching_live_room` results, and `failed` counts per-hotel errors. Keep successful items when another item fails. Each successful item may include that hotel's read-only `web_url`.
+
 ### `POST /skill/tob/check_room_availability`
 
-Request: `token`, string `hotel_id`, `rate_code`, dates, `adults`, `room_count`.
+Request: `token`, string `hotel_id`, `rate_code`, dates, `adults`, `room_count`, `children`, `children_ages`. Occupancy fields retain the same per-room meaning.
 
 Use the selected `query_room_rates` rate code. The checked response may return a new rate code, price and cancellation details. Use the checked values—not the earlier query values—for booking.
 
@@ -283,7 +323,7 @@ Request fields:
 | `check_in_date`, `check_out_date` | yes | Confirmed dates |
 | `guest_name` | yes | User's full legal name |
 | `contact_email` | **yes** | User-supplied valid email |
-| `adults`, `room_count` | yes | Confirmed occupancy |
+| `adults`, `room_count`, `children`, `children_ages` | yes | Confirmed per-room occupancy; use 0 and `[]` when there are no children |
 | `currency`, `total_price` | yes | Latest availability check |
 
 The backend may technically accept an omitted email, but this skill must not call `create_booking` without one. Do not offer a skip option. A basic plausibility check requires one `@`, non-empty local/domain parts and a domain containing a dot; do not overclaim deliverability validation.
@@ -313,7 +353,7 @@ There is no custom return URL. Return `pay_url` to the user. For Stripe, also sh
 Use all candidates needed for a fair top-five choice; do not merely display the first five cached-price rows.
 
 1. Preserve the complete original `search_hotels` candidate pool. Exclude search-level hard failures, including explicit radius and star constraints, only from the recommendation pool; record all failed hard constraints on the original candidate.
-2. Query live rates for remaining candidates in controlled batches.
+2. Call `batch_query_room_rates` once for the remaining candidates, with at most 20 hotel IDs. Process each item independently and retain partial successes.
 3. Filter products by occupancy, room count, strict budget, requested room/meal and other hard fields.
 4. Drop candidates with no matching live product only from the recommendation pool; retain their identifiers and `no matching live product` status in the original pool.
 5. Treat `is_on_request=true` as supplier-confirmation inventory, not immediate availability. Exclude it when the user explicitly requires immediately bookable or real-time available inventory; otherwise rank it after `is_on_request=false` and use the localized label equivalent of `Inventory requires supplier confirmation`.
@@ -414,8 +454,14 @@ Common order statuses:
 | `unauthorized` / HTTP 401 | Delete the token file, display the required sign-in/token/registration guidance from `SKILL.md`, and request a replacement token |
 | No search candidates | Report the exact constraint set; offer changes without applying them |
 | Candidates but no live products | State that hotels were found but none had matching live rooms |
+| `reason=no_matching_live_room` | Treat as a successful business-empty result and suggest changing dates or occupancy |
+| `reason=hotel_not_found` | State that the hotel is missing or unavailable |
+| `reason=upstream_timeout` | State that real-time pricing timed out and may be retried later |
+| `reason=upstream_error` | Report a temporary service failure; never describe it as no availability |
+| `reason=hotel_detail_unavailable` | Report that hotel details required for the room response are temporarily unavailable |
+| `reason=invalid_request` | Correct the request before retrying |
 | Budget-capped search empty | Optionally probe without budget only to diagnose over-budget inventory |
 | Rate check failed | Re-run availability once for the selected rate; if still failed, report it |
 | Booking creation failed | Report the error; do not retry with guessed guest/order data |
 
-Batch rate/detail calls conservatively to avoid API throttling. Parallelize independent read-only queries in small batches, but keep booking, cancellation and payment operations sequential and explicitly confirmed.
+Use `batch_query_room_rates` for multi-hotel rate retrieval, with at most 20 hotels per request. Keep booking, cancellation and payment operations sequential and explicitly confirmed.

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -132,6 +132,7 @@ class RepositoryContractTests(unittest.TestCase):
             "search_hotels",
             "get_hotel_detail",
             "query_room_rates",
+            "batch_query_room_rates",
             "check_room_availability",
             "create_booking",
             "query_booking",
@@ -141,6 +142,55 @@ class RepositoryContractTests(unittest.TestCase):
         for endpoint in endpoints:
             with self.subTest(endpoint=endpoint):
                 self.assertIn(endpoint, text)
+
+    def test_official_skill_identity(self) -> None:
+        skill_text = SKILL.read_text(encoding="utf-8")
+        metadata = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
+        self.assertIn("# TourMind Booking Skill", skill_text)
+        self.assertIn("### TourMind Booking Skill is ready", skill_text)
+        self.assertIn("name: tourmind-booking", skill_text)
+        self.assertIn('display_name: "TourMind Hotel Booking"', metadata)
+        self.assertIn("$tourmind-booking", metadata)
+        self.assertNotIn("booking_test", skill_text)
+        self.assertNotIn("tourmind-booking-test", metadata)
+
+    def test_final_confirmation_includes_child_occupancy(self) -> None:
+        text = SKILL.read_text(encoding="utf-8")
+        self.assertIn("{children_per_room}", text)
+        self.assertIn("{children_ages_per_room_or_not_applicable}", text)
+        self.assertIn("When there are no children", text)
+
+    def test_batch_rate_client_concurrency_limit(self) -> None:
+        skill_text = SKILL.read_text(encoding="utf-8")
+        reference_text = (ROOT / "references" / "parameter_guide.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("up to three `batch_query_room_rates` requests concurrently", skill_text)
+        self.assertIn("never exceed three concurrent requests", skill_text)
+        self.assertIn("at most three concurrent batch requests per client", reference_text)
+        self.assertNotIn("Do not wrap this endpoint in another client-side concurrency pool", reference_text)
+
+    def test_api_base_url_is_production(self) -> None:
+        documents = (
+            SKILL,
+            ROOT / "references" / "parameter_guide.md",
+            *READMES,
+        )
+        for document in documents:
+            with self.subTest(document=document.name):
+                text = document.read_text(encoding="utf-8")
+                self.assertIn("https://api.tourmind.com", text)
+                self.assertNotIn("http://39.108.114.224:9028", text)
+
+    def test_rate_reason_codes_have_explicit_scope(self) -> None:
+        skill_text = SKILL.read_text(encoding="utf-8")
+        reference_text = (ROOT / "references" / "parameter_guide.md").read_text(
+            encoding="utf-8"
+        )
+        for text in (skill_text, reference_text):
+            self.assertIn("`query_room_rates` responses", text)
+            self.assertIn("`batch_query_room_rates.data.results[]` items", text)
+            self.assertIn("`invalid_request` may also", text)
 
     def test_credentials_are_not_tracked(self) -> None:
         tracked = subprocess.run(


### PR DESCRIPTION
## Summary

- add per-room adult and child occupancy guidance across search, rate check, availability, and booking
- add `batch_query_room_rates` for multi-hotel live rate verification
- allow up to 20 hotels per batch and up to 3 concurrent client batch requests
- preserve partial batch successes and scope rate-query reason codes explicitly
- include child count and ages in the final booking confirmation
- keep the production API endpoint and restore the official `tourmind-booking` identity and onboarding text
- add repository contract coverage for the new endpoint and workflow rules

## Validation

- `python3 -m unittest discover -s tests -v`
- 21 tests passed
- `git diff --check`
