### PR TITLE
fix: handle missing hotel business permission

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -86,13 +86,14 @@ All endpoints use `POST` with JSON and require `token` from `{baseDir}/skill_tok
 | Start payment | `/skill/tob/pay_order` |
 
 Success: `{"ok": true, "data": {...}}`
-Failure: `{"ok": false, "error": "..."}`
+Failure: `{"ok": false, "error_code": "...", "error": "..."}`. `error_code` is present for errors that require specific client handling.
 
 Before calling an endpoint:
 
 1. Read `{baseDir}/skill_token.txt`.
 2. If it is absent or empty, do not call the API. Display the required access guidance below, ask the user to provide the newly created token, and save it to that file.
 3. If an HTTP 401 or an error containing `unauthorized` is returned, delete `{baseDir}/skill_token.txt`, stop the workflow, and display the same guidance before requesting a replacement token.
+4. If HTTP 403 with `error_code=HOTEL_BUSINESS_PERMISSION_REQUIRED` is returned, stop the hotel workflow and tell the user that hotel business access is not enabled for their TourMind account. Ask them to contact their account administrator or TourMind support to enable it. Do not delete or replace the token, and do not retry the request, because the token itself is valid.
 
 Required access guidance. The following English text is canonical source wording; translate it into the user's language while preserving both URLs and the distinction between business, developer, and individual users:
 

--- a/references/parameter_guide.md
+++ b/references/parameter_guide.md
@@ -454,6 +454,7 @@ The `reason` codes in the table below apply to `query_room_rates` responses and 
 | Error/symptom | Required handling |
 |---|---|
 | `unauthorized` / HTTP 401 | Delete the token file, display the required sign-in/token/registration guidance from `SKILL.md`, and request a replacement token |
+| `error_code=HOTEL_BUSINESS_PERMISSION_REQUIRED` / HTTP 403 | Stop the hotel workflow. State that hotel business access is not enabled for the user's TourMind account and ask them to contact their account administrator or TourMind support. Keep the token file; replacing the token does not grant the missing permission |
 | No search candidates | Report the exact constraint set; offer changes without applying them |
 | Candidates but no live products | State that hotels were found but none had matching live rooms |
 | `reason=no_matching_live_room` | Treat as a successful business-empty result and suggest changing dates or occupancy |

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -192,6 +192,18 @@ class RepositoryContractTests(unittest.TestCase):
             self.assertIn("`batch_query_room_rates.data.results[]` items", text)
             self.assertIn("`invalid_request` may also", text)
 
+    def test_missing_hotel_business_permission_keeps_token(self) -> None:
+        skill_text = SKILL.read_text(encoding="utf-8")
+        reference_text = (ROOT / "references" / "parameter_guide.md").read_text(
+            encoding="utf-8"
+        )
+        for text in (skill_text, reference_text):
+            self.assertIn("HOTEL_BUSINESS_PERMISSION_REQUIRED", text)
+            self.assertIn("HTTP 403", text)
+        self.assertIn("Do not delete or replace the token", skill_text)
+        self.assertIn("do not retry the request", skill_text)
+        self.assertIn("Keep the token file", reference_text)
+
     def test_credentials_are_not_tracked(self) -> None:
         tracked = subprocess.run(
             ["git", "ls-files"],


### PR DESCRIPTION
## Summary

- include optional `error_code` in the documented failure shape
- handle HTTP 403 with `HOTEL_BUSINESS_PERMISSION_REQUIRED`
- stop the hotel workflow without deleting or replacing a valid token
- avoid retries that cannot grant missing account permission
- direct users to their account administrator or TourMind support
- add repository contract coverage for the permission behavior

## Validation

- `python3 -m unittest discover -s tests -v`
- 22 tests passed
- `git diff --check`
