### PR TITLE
Unify personal and business booking flows

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -8,47 +8,35 @@ description: >
 
 **Skill version:** `1.0.6`
 
-Use TourMind HTTP APIs for live hotel discovery, room-rate comparison, availability checks, booking, order management and payment.
+Use TourMind for live hotel discovery, room-rate comparison, availability checks, booking, order management and payment. With no token, use the public personal channel. With a token beginning `uk_`, use the authenticated personal channel. With a token beginning `sk_`, use the business channel.
 
 ## Post-install first-run guidance
 
-Immediately after this Skill is installed, before handling the user's first hotel task, show the following onboarding message exactly once. Do not summarize, shorten, or omit any part of it. Translate the user-visible text into the user's language while preserving the Markdown structure, URLs, product names, payment names, and example prompts. The required access guidance is mandatory for the ToB Skill because every API call requires a Skill Token.
+Immediately after this Skill is installed, before handling the user's first hotel task, show the following complete onboarding message exactly once. Do not summarize, shorten, convert it into a capability list, or omit any part of it. Translate the entire message naturally into the user's current language while preserving the Markdown structure, URLs, product names, and the complete intent of all three examples.
 
 ````markdown
 ### TourMind Booking Skill is ready
 
-Before you start, please create and install your Skill Token.
+You can start using it now.
 
-Please sign in to your TourMind account, then visit [Create a Skill Token](https://tourmind.com/user/skill-token) to create a token for this Skill.
-
-If you do not have an account, register for a business account at [Business account registration](https://tourmind.com/admin/skillSignup). Developers and individual users should use the TourMind Skill version intended for their user type instead.
-
-After you create the token, paste only the raw token into `{baseDir}/skill_token.txt`. Keep it out of prompts, screenshots, Git commits, issue reports, and shared logs.
-
-You can now use this Skill to:
-
-- Search hotels by city, landmark, station, address, hotel name, or nearby location.
-- Compare live room rates, stay totals, meals, cancellation policies, images, amenities, and availability.
-- Open repeatable read-only result links when the API returns them.
-- Recheck the selected room's final price and availability before booking.
-- Create bookings, start Stripe, WeChat Pay, or Alipay payment, query orders, and cancel eligible bookings after explicit confirmation.
-
-Try one of these examples:
+You can ask me like this:
 
 ```text
-Search hotels near Shenzhen Xili for September 12 to September 13, 2026, for one adult. Show five options with live prices, distance, cancellation policy, and a repeatable result link if available. Do not book yet.
+I am visiting Paris next month for four nights with one other person. I would like to stay near the Louvre or the Opera, with a budget of about EUR 200 per night. Help me find a few well-located hotels.
 ```
 
 ```text
-Find a hotel in Tokyo near Shinjuku Station from April 3 to April 7, 2027, for two adults. Prefer breakfast, free cancellation, and a total stay price under JPY 120,000. Show room photos and verified stay totals.
+I am taking my family to Tokyo this summer and would like to stay near Shinjuku. I prefer somewhere quiet, with breakfast and free cancellation. Pick a few hotels and explain who each one suits.
 ```
 
 ```text
-Use the second hotel from the results. Show the available room types, bed type, meal plan, cancellation policy, nightly price, stay total, and inventory status. Recheck the best room before asking me to confirm booking.
+I am planning a honeymoon in Bali and want to stay in Nusa Dua, preferably by the beach with a pool and under USD 300 per night. Show me some suitable resorts.
 ```
+
+For access to the best channel prices and price-markup and commission capabilities, apply for a business account at [TourMind registration](https://tourmind.com/admin/skillSignup). Registered users or users who already have a TourMind account can visit [Create a private token](https://tourmind.com/user/skill-token), create a TourMind private token, and send it to me to connect the business channel.
 ````
 
-Show this post-install message only for the first run after installation. For later normal hotel requests, do not repeat it. If the token is absent, empty, invalid, or unauthorized during use, show the required access guidance from the API and authentication section.
+Show this post-install message only for the first run after installation. Do not repeat it for later normal hotel requests. With no token, do not let sign-in, registration, or identity selection block hotel search, hotel details, room-rate queries, or availability checks. When the user sends a token, the Agent saves it to `{baseDir}/skill_token.txt`; never ask the user to create, edit, or manage that local file.
 
 ## Response language
 
@@ -60,64 +48,116 @@ Respond in the language used by the user's current request unless the user expli
 2. Before the first hotel-search API call, require a location, check-in date and check-out date. The scheduled update check does not require these fields. If adult count is omitted, use 1 adult per room and explicitly tell the user that the search assumes one guest; invite them to provide the guest count for multiple occupancy. Apply the safe defaults below instead of asking unnecessary questions.
 3. Treat `search_hotels.min_price` as a cached candidate signal only. Present a hotel as having a live rate product and quote a price only after `query_room_rates` or a successful `batch_query_room_rates` item returns a matching product. Describe inventory as immediately bookable only when that product has `is_on_request=false`.
 4. Respect explicit radius, budget, star, occupancy and facility requirements as hard constraints. Never silently expand a hard radius or budget.
-5. Before every `create_booking`, require the guest's full legal name and a valid `contact_email`. Email is mandatory in this skill even if the backend accepts an omitted value. Never offer a skip option, invent an email or reuse an unconfirmed email. Do not collect a phone number.
-6. Interpret cancellation policies exactly as returned. `non_refundable` or `effective_non_refundable=true` means non-refundable. `free_cancel_before_deadline` means free cancellation only through its deadline.
-7. State in the final booking-confirmation template that the TourMind room price is tax included. Also state that a small number of destinations require hotels to collect city or tourism taxes at check-in; surface any explicit `hotel.fees.mandatory` disclosure separately, and do not invent an amount or charging basis. Stripe adds a separate 3.5% processing fee only when the user chooses Stripe.
-8. If any hotel, rate, booking, order or payment API call fails, report the exact error after the allowed retry. Do not substitute invented results or unrelated recommendations. A scheduled update-check failure follows the non-blocking rule below.
+5. Every `search_hotels.lowest_price` and `search_hotels.highest_price` value **must be sent in CNY** and must represent the entire stay across all requested rooms, never a nightly value. If the user's budget is in another currency, obtain a current live exchange rate and convert each bound to CNY immediately before the search; never use a remembered, assumed, or stale rate. For a per-room nightly range, calculate `user_currency_bound × live_CNY_rate × night_count × room_count`. For one room over three nights at CNY 300–400 per night, send `lowest_price=900` and `highest_price=1200`. If the user explicitly gives a whole-trip total, convert that total to CNY when necessary but do not multiply it by nights or rooms again.
+6. Before every `create_booking`, require the guest's full legal name and a valid `contact_email`. Email is mandatory in this skill even if the backend accepts an omitted value. Never offer a skip option, invent an email or reuse an unconfirmed email. Do not collect a phone number.
+7. Interpret cancellation policies exactly as returned. `non_refundable` or `effective_non_refundable=true` means non-refundable. `free_cancel_before_deadline` means free cancellation only through its deadline.
+8. State in the final booking-confirmation template that the TourMind room price is tax included. Also state that a small number of destinations require hotels to collect city or tourism taxes at check-in; surface any explicit `hotel.fees.mandatory` disclosure separately, and do not invent an amount or charging basis. Stripe adds a separate 3.5% processing fee only when the user chooses Stripe.
+9. If any hotel, rate, booking, order or payment API call fails, report the exact error after the allowed retry. Do not substitute invented results or unrelated recommendations. A scheduled update-check failure follows the non-blocking rule below.
+10. A rate and order workflow belongs to exactly one channel. Never reuse a `rate_code`, price, cancellation policy, availability state, payment context, or order-operation context across the personal and business channels.
 
 ## API and authentication
 
 **Base URL:** `https://api.tourmind.com`
 
-All endpoints use `POST` with JSON and require `token` from `{baseDir}/skill_token.txt`.
+All endpoints use `POST` with JSON. Read the single credential file `{baseDir}/skill_token.txt` at the start of each workflow and select the channel from its content:
 
-| Capability | Path |
-|---|---|
-| Check for a Skill update | `/skill/tob/check_skill_update` |
-| Resolve region, POI or hotel | `/skill/tob/search_location` |
-| Search hotel candidates | `/skill/tob/search_hotels` |
-| Get hotel details and images | `/skill/tob/get_hotel_detail` |
-| Get live rooms and rates | `/skill/tob/query_room_rates` |
-| Get live rooms and rates for multiple hotels | `/skill/tob/batch_query_room_rates` |
-| Recheck rate and availability | `/skill/tob/check_room_availability` |
-| Create booking | `/skill/tob/create_booking` |
-| Query booking | `/skill/tob/query_booking` |
-| Cancel booking | `/skill/tob/cancel_booking` |
-| Start payment | `/skill/tob/pay_order` |
+| Credential state | User state | Active channel | Request rule |
+|---|---|---|---|
+| File absent or empty | Signed-out browsing user | Public personal channel (ToC) | Send no credential for search, detail, rates, or availability; guide sign-in only before an order operation |
+| Begins with `uk_` | Personal user | Personal channel (ToC) | Send it as `user_key` only when the corresponding ToC endpoint accepts or requires it |
+| Begins with `sk_` | Business user | Business channel (ToB) | Send it as `token` to every ToB endpoint |
+| Any other content | Unrecognized | No business endpoint | Tell the user that the token format is unrecognized and ask for a complete token beginning `uk_` or `sk_` |
+
+The prefix selects the channel and credential field; it is not proof of authorization. The server response remains authoritative. Never send a `uk_` token to ToB or an `sk_` token to ToC.
+
+| Capability | Personal path | Personal authentication | Business path | Business authentication |
+|---|---|---|---|---|
+| Check for a Skill update | `/skill/toc/check_skill_update` | No `user_key` | `/skill/tob/check_skill_update` | Required `token` |
+| Resolve region, POI or hotel | `/skill/toc/search_location` | No `user_key` | `/skill/tob/search_location` | Required `token` |
+| Search hotel candidates | `/skill/toc/search_hotels` | Public; when a stored `uk_` exists, include `user_key` only if the endpoint contract accepts it | `/skill/tob/search_hotels` | Required `token` |
+| Get hotel details and images | `/skill/toc/get_hotel_detail` | No `user_key` | `/skill/tob/get_hotel_detail` | Required `token` |
+| Get live rooms and rates | `/skill/toc/query_room_rates` | Public; when a stored `uk_` exists, include `user_key` only if the endpoint contract accepts it | `/skill/tob/query_room_rates` | Required `token` |
+| Get live rooms and rates for multiple hotels | `/skill/toc/batch_query_room_rates` | Public; when a stored `uk_` exists, include `user_key` only if the endpoint contract accepts it | `/skill/tob/batch_query_room_rates` | Required `token` |
+| Recheck rate and availability | `/skill/toc/check_room_availability` | No `user_key` | `/skill/tob/check_room_availability` | Required `token` |
+| Create booking | `/skill/toc/create_booking` | Required `user_key` | `/skill/tob/create_booking` | Required `token` |
+| Query booking | `/skill/toc/query_booking` | Required `user_key` | `/skill/tob/query_booking` | Required `token` |
+| Cancel booking | `/skill/toc/cancel_booking` | Required `user_key` | `/skill/tob/cancel_booking` | Required `token` |
+| Start payment | `/skill/toc/pay_order` | Required `user_key` | `/skill/tob/pay_order` | Required `token` |
+
+Credential fields are strictly channel-bound:
+
+- A personal-channel credential is only `{"user_key": "uk_..."}`; omit it on public endpoints that do not need identity.
+- Every business-channel request uses `{"token": "sk_..."}`.
+- Never send `user_key` to the business channel, never send `token` to the personal channel, and never include both fields in one request.
 
 Success: `{"ok": true, "data": {...}}`
 Failure: `{"ok": false, "error_code": "...", "error": "..."}`. `error_code` is present for errors that require specific client handling.
 
-Before calling an endpoint:
+The optional read-only result link from `search_hotels`, `query_room_rates`, or a successful `batch_query_room_rates` item is at that response or item's `data.web_url`; its expiry and one-time status are in the same `data` object at `web_url_expires_at` and `web_url_one_time`. If these fields are absent, omit the link. Never construct one or require sign-in only to obtain it.
 
-1. Read `{baseDir}/skill_token.txt`.
-2. If it is absent or empty, do not call the API. Display the required access guidance below, ask the user to provide the newly created token, and save it to that file.
-3. If an HTTP 401 or an error containing `unauthorized` is returned, delete `{baseDir}/skill_token.txt`, stop the workflow, and display the same guidance before requesting a replacement token.
-4. If HTTP 403 with `error_code=HOTEL_BUSINESS_PERMISSION_REQUIRED` is returned, stop the hotel workflow and tell the user that hotel business access is not enabled for their TourMind account. Ask them to contact their account administrator or TourMind support to enable it. Do not delete or replace the token, and do not retry the request, because the token itself is valid.
+### Receiving and saving a token
 
-Required access guidance. The following English text is canonical source wording; translate it into the user's language while preserving both URLs and the distinction between business, developer, and individual users:
+When the user voluntarily sends a token:
 
-> Please sign in to your TourMind account, then visit [Create a Skill Token](https://tourmind.com/user/skill-token) to create a token for this Skill.
+1. Trim leading and trailing whitespace without changing internal characters.
+2. Accept only a complete token beginning `uk_` or `sk_`.
+3. Save it to `{baseDir}/skill_token.txt`, replacing the previous single credential. Do not ask the user to manage the file.
+4. After saving, never repeat the complete token in a response, log, screenshot, Git commit, issue, or shared report.
+5. Select the channel from the prefix. If the channel changes, follow **Channel switching and rate invalidation** below.
+
+### Order guidance when no token exists
+
+`create_booking`, `query_booking`, `cancel_booking`, and `pay_order` are order operations. With no token, pause the order operation and show the complete guidance below. Translate it into the user's current language without omitting either user type, either URL, email verification, token prefixes, or the browser-assistance note:
+
+> Before continuing with a booking or order management, please tell me whether you are a personal user or a business user:
 >
-> If you do not have an account, register for a business account at [Business account registration](https://tourmind.com/admin/skillSignup). Developers and individual users should use the TourMind Skill version intended for their user type instead.
+> - Personal user: open [Journione sign-in](https://auth.journione.ai), sign in by verifying your email, then copy the token beginning `uk_` from the right side of the page and send it to me. If you have trouble registering or signing in, I can open the link in my built-in browser and help you complete the process.
+> - Business user: first sign in to your TourMind account, then visit [Create a private token](https://tourmind.com/user/skill-token), create a TourMind private token beginning `sk_`, and send it to me.
+
+If the user has already provided a token, infer personal or business status from `uk_` or `sk_`; do not ask the identity question again.
+
+### Unauthorized handling
+
+If HTTP 401 or an error containing `unauthorized` is returned:
+
+1. Delete `{baseDir}/skill_token.txt`, stop the operation requiring authentication, and do not reuse the invalid token.
+2. Do not silently downgrade from the business channel to the public personal channel or silently try the other channel.
+3. For search, detail, rate, or availability work, tell the user that sign-in expired and offer to continue through the public personal channel. Switch and re-query only after the user agrees.
+4. For an order operation, show the reauthentication guidance matching the invalid token's prefix. If the prefix is unknown, show both personal and business choices again.
+
+If a business-channel request returns HTTP 403 with `error_code=HOTEL_BUSINESS_PERMISSION_REQUIRED`, stop the hotel workflow and tell the user that hotel business access is not enabled for their TourMind account. Ask them to contact their account administrator or TourMind support to enable it. Do not delete or replace `{baseDir}/skill_token.txt`, do not switch channels silently, and do not retry the request, because the `sk_` token itself is valid.
+
+### Channel switching and rate invalidation
+
+Record the active channel throughout each hotel selection, rate check, booking, payment, or order-management workflow.
+
+- No token or `uk_` to `sk_` changes from the personal channel to the business channel.
+- `sk_` to no token or `uk_` changes from the business channel to the personal channel.
+- No token to `uk_` remains on the personal channel, but still requires a final availability and price check before order creation.
+
+Whenever the channel changes:
+
+1. Invalidate every `rate_code`, price, cancellation policy, availability state, and payment context returned by the previous channel.
+2. Re-query live rooms for the selected hotel through the new channel. Even if `hotel_id` appears identical, do not assume that the products are identical.
+3. Call `check_room_availability` again with a `rate_code` returned by the new channel.
+4. Show the new channel's final price, cancellation policy, and availability; explicitly disclose any change.
+5. Obtain a new explicit confirmation of the final booking details before creating the order.
+
+After order creation, payment, query, and cancellation must continue on the channel that created the order and with a matching-prefix credential. If the current credential does not match the order channel, stop and ask for the credential used to create that order. Never probe both channels sequentially.
 
 ## Skill version and update check
 
 Use the version declared immediately below this document's title as the installed `current_version`. Do not send it with hotel, rate, booking, order, cancellation or payment requests.
 
-Call `POST /skill/tob/check_skill_update` with:
+Choose the update endpoint from the current credential state:
 
-```json
-{
-  "token": "<skill-token>",
-  "current_version": "<declared-skill-version>"
-}
-```
+- With no token or a token beginning `uk_`, call `POST /skill/toc/check_skill_update` with only `current_version`.
+- With a token beginning `sk_`, call `POST /skill/tob/check_skill_update` with `token` and `current_version`.
 
 Call it only:
 
-1. The first time this Skill is used in every new conversation, before the first business API call.
-2. When an existing conversation is resumed after at least 24 hours of inactivity, before the next business API call.
+1. The first time this Skill is used in every new conversation, before the first workflow API call.
+2. When an existing conversation is resumed after at least 24 hours of inactivity, before the next workflow API call.
 
 Do not call it again before every endpoint. If no reliable update-check state exists in the current conversation context, treat the use as the first use in a new conversation. If the check fails, continue the user's hotel task and do not repeatedly retry or show an update-check error unless the user explicitly asked about updates.
 
@@ -147,11 +187,21 @@ Do not ask for information that can be inferred safely. State every applied assu
 | Relative date such as tonight or tomorrow | Resolve it to exact dates in the user's timezone. |
 | "Nearby" or "as close as possible" with no radius | Use 3 km and state that default. |
 | Sort order omitted | Rank by verified preference match, then distance, live total price and cancellation flexibility. |
-| Budget wording such as "under 2000" is ambiguous | Clarify whether it is per night or trip total before applying a hard filter. |
+| Hotel price range such as "300–400" without explicit trip-total wording | Treat it as a per-room nightly range and state that assumption. Convert the amount to CNY with a current live exchange rate when necessary, then multiply both bounds by the number of nights and `room_count` for `lowest_price` and `highest_price`. Ask only when the surrounding context makes the price basis genuinely unclear. |
+| Budget explicitly stated as a trip total | Convert the stated total to CNY with a current live exchange rate when necessary, but do not multiply it by nights or rooms again. |
+| Result display currency omitted | For a request written in Chinese, display hotel-list and room-rate prices in CNY. For English and every other non-Chinese language, display them in USD. An explicitly requested display currency always overrides this default. |
 
 Still ask when the location, check-in date or check-out date cannot be inferred. Never replace an adult count the user already provided. Ensure checkout is later than check-in and all dates sent to the API use `YYYY-MM-DD`.
 
 `adults`, `children`, and `children_ages` describe **each room**, while `room_count` repeats that same occupancy for all rooms. `children_ages` must contain one age from 0 through 17 for each child in one room. For example, `adults=2, room_count=2, children=1, children_ages=[8]` means two rooms, each with two adults and one eight-year-old child. If the user gives only total guests for multiple rooms, ask for the per-room occupancy before calling the API. Do not send `room_occupancies`; mixed per-room configurations are not supported.
+
+### Search currency and result display currency
+
+- Before sending any non-CNY price bound to `search_hotels`, obtain a current live exchange rate from the user's currency to CNY. If no live rate can be obtained, do not guess: ask the user for a CNY budget or offer to search without a price filter after explaining the limitation.
+- Price-bound conversion and stay-total conversion are separate operations. Convert the source amount to CNY, then multiply by `night_count × room_count` only when the source amount is per room per night.
+- For hotel-list and room-rate results, choose one default display currency from the current request language: Chinese → CNY; every non-Chinese language, including English → USD. Use another currency only when the user explicitly requests it.
+- When a returned live rate is not already in the selected display currency, obtain a current live exchange rate and convert both per-night and stay-total values consistently. Label converted display amounts as approximate and disclose the exchange rate, source, and retrieval time. Never relabel a number without conversion.
+- Display conversion is presentation only. Preserve the original returned currency and amounts internally. `check_room_availability`, final booking confirmation, and `create_booking` must use the latest checked transaction currency and amount, not an approximate display conversion.
 
 ## Location and POI resolution
 
@@ -159,7 +209,7 @@ Choose a location route before searching rates:
 
 ### Region-first destination search
 
-For a city, administrative area, neighborhood, business district, large attraction, scenic area, national park, ski area, resort or island, call `search_location` and inspect `data.regions[]` before `data.place`, unless the user explicitly asked for a precise point or radius. A region usually represents where travelers commonly stay more accurately than a single geographic pin.
+For a city, administrative area, neighborhood, business district, large attraction, scenic area, national park, ski area, resort or island, call the active channel's `search_location` and inspect `data.regions[]` before `data.place`, unless the user explicitly asked for a precise point or radius. A region usually represents where travelers commonly stay more accurately than a single geographic pin.
 
 Choose a region only when it is a high-confidence match:
 
@@ -168,20 +218,20 @@ Choose a region only when it is a high-confidence match:
 3. Its `region_type` is reasonable for the requested destination. A positive `hotel_count`, when present, is strong supporting evidence but is not sufficient by itself.
 4. Reject unrelated same-name results. If multiple regions remain genuinely plausible and the user's context cannot distinguish them, ask one focused clarification instead of guessing.
 
-Pass the selected string `region_id` and resolved region name as `location_name` to `search_hotels`. Preserve and display returned distances and area names truthfully; a region search may cover several popular lodging clusters. Do not switch to `data.place` merely because it exists when a reliable region match is available.
+Pass the selected string `region_id` and resolved region name as `location_name` to the active channel's `search_hotels`. Preserve and display returned distances and area names truthfully; a region search may cover several popular lodging clusters. Do not switch to `data.place` merely because it exists when a reliable region match is available.
 
 ### Exact hotel name
 
-Call `search_hotels` in keyword mode to resolve the hotel and coordinates. Use `get_hotel_detail` for static details and `query_room_rates` for live prices.
+Call the active channel's `search_hotels` in keyword mode to resolve the hotel and coordinates. Use that channel's `get_hotel_detail` for static details and `query_room_rates` for live prices.
 
 ### Exact point or explicit nearby request
 
 Use nearby mode for a station, address, specific entrance, compact landmark, map pin, or any request with an explicit radius or wording that clearly requires distance from that exact point:
 
-1. Call `search_location` with the user's full POI phrase and destination context.
+1. Call the active channel's `search_location` with the user's full POI phrase and destination context.
 2. Use `data.place` only when its name, address and country/city context match the requested point. The API returns one Google Places result; do not silently accept a mismatched point.
 3. Preserve the user's explicit radius exactly. Otherwise use `place.recommended_radius_km` (currently 3 km).
-4. Call `search_hotels` with `place.latitude`, `place.longitude`, the selected `radius_km`, and `location_name=place.name`.
+4. Call the active channel's `search_hotels` with `place.latitude`, `place.longitude`, the selected `radius_km`, and `location_name=place.name`.
 5. State the returned `search_scope` to the user. Never widen an explicit radius without permission.
 
 ### Broad-POI fallback when no reliable region exists
@@ -200,17 +250,19 @@ Never invent coordinates, geocode from model memory or substitute a city-wide se
 
 ## Search, verify and select five
 
-Region and nearby `search_hotels` calls return at most 20 candidates that have already passed a live-rate availability probe for the requested dates and occupancy. Keyword mode remains a hotel-name lookup and does not perform that probe. Treat `min_price` as cached display data even for live-filtered candidates; use room-rate products for prices.
+Region and nearby `search_hotels` calls return at most 20 candidates that have already passed a live-rate availability probe for the requested dates and occupancy. Keyword mode remains a hotel-name lookup and does not perform that probe. Treat this as a candidate pool, not the final answer, and continue to treat `min_price` as cached display data even for live-filtered candidates.
 
 1. Parse the user's requirements into:
    - **Hard constraints:** dates, occupancy, room count, explicit radius, strict budget, required star level, required facilities or property type.
    - **Soft preferences:** closer, cheaper, higher star level, breakfast, free cancellation, preferred facilities or room type.
-2. Call `search_hotels` with the applicable hard search fields. Preserve the complete raw candidate pool and `distance_km` values so a later "show all" request can be fulfilled.
-   - Preserve the top-level `web_url` and include it as a clickable read-only hotel-results link. Place the link guidance after the search-summary fields and before the first recommended hotel, with one blank line on each side. Tell the user to open a hotel detail page, click the copy button beside the desired room product, and send the copied product information back in the conversation so you can continue verification and booking. Do not expose the underlying token or alter the URL. The linked session only permits hotel lists, hotel details and room quotes; it does not permit verification, booking, payment, `/book/*`, order, finance or account-management pages.
+2. Normalize every price filter before calling the active channel's `search_hotels`. Both price fields **must be CNY whole-stay totals across all requested rooms**. If the user's amount is not CNY, obtain a current live rate and first calculate `source_bound × live_CNY_rate`; for a per-room nightly amount, then multiply by `night_count × room_count`. For one room over three nights at CNY 300–400 per night, send `lowest_price=900` and `highest_price=1200`; never send `300` and `400` as though the fields were nightly. If the user explicitly supplied a whole-trip total, convert it to CNY when necessary but do not multiply it again. Then call `search_hotels` with the applicable hard search fields. Preserve the complete raw candidate pool and `distance_km` values so a later "show all" request can be fulfilled.
+   - If the response contains `data.web_url`, include it as a clickable read-only hotel-results link. Place the link guidance after the search-summary fields and before the first recommended hotel, with one blank line on each side. Tell the user to open a hotel detail page, click the copy button beside the desired room product, and send the copied product information back in the conversation so you can continue verification and booking. Do not expose the underlying token or alter the URL. The linked session only permits hotel lists, hotel details and room quotes; it does not permit verification, booking, payment, `/book/*`, order, finance or account-management pages.
+   - If `data.web_url` is absent, continue with the hotel results and omit the link. Never construct a link or require a token only to populate this optional field.
 3. Exclude obvious hard-constraint failures from the recommendation/ranking pool, but retain them in the raw pool with every failed constraint recorded.
-4. Call `batch_query_room_rates` with the remaining candidate IDs needed to rank the recommendation pool fairly. Put at most 20 hotels in each request. When more than one batch is required, the client may run up to three `batch_query_room_rates` requests concurrently; never exceed three concurrent requests. The server still owns the four-worker concurrency within each batch. Use `query_room_rates` when only one hotel needs rates. Exclude candidates with no matching live product from recommendations, but retain their no-live-product status in the raw pool.
+4. Call the active channel's `batch_query_room_rates` with the remaining candidate IDs needed to rank the recommendation pool fairly. Put at most 20 hotels in each request. When more than one batch is required, the client may run up to three `batch_query_room_rates` requests concurrently; never exceed three concurrent requests. The server owns the worker concurrency within each batch. Use `query_room_rates` when only one hotel needs rates. Do not stop at the first five cached-price results. Exclude candidates with no matching live product from recommendations, but retain their no-live-product status in the raw pool.
    - Read every batch item independently. A top-level successful batch may contain matched, empty, and failed hotel items; never discard successful items because another hotel failed.
-   - Preserve each successful batch item's `data.web_url`, or the single-hotel response's top-level `web_url`, as that exact hotel's `hotel_web_url`. Never reuse the hotel-list `search_hotels.web_url` for an individual hotel.
+   - Do not call individual `query_room_rates` merely to replace a missing, empty, or failed batch item. Interpret that item's `reason` and retain the truthful partial result.
+   - Preserve each successful batch item's `data.web_url`, or the single-hotel response's `data.web_url`, as that exact hotel's `hotel_web_url`. Never reuse the hotel-list `search_hotels.data.web_url` for an individual hotel.
    - `is_on_request=false` is immediately bookable inventory.
    - `is_on_request=true` is a request product whose inventory still needs supplier confirmation. It does not satisfy an explicit "immediately bookable" or "real-time availability" hard requirement; otherwise keep it eligible but rank it after immediately bookable options and label it clearly.
 5. If a required or preferred facility cannot be verified from search data, call `get_hotel_detail` for the relevant candidates before ranking it.
@@ -242,8 +294,9 @@ Found {candidate_count} candidate hotels and verified live room products for {ve
 
 Search area: {region_or_poi_and_radius_resolution_note}
 Stay: {check_in_date} to {check_out_date}, {night_count} nights
-Guests: {total_adults} adults, {room_count} rooms ({occupancy_distribution})
+Guests: {total_adults} adults, {total_children} children, {room_count} rooms ({occupancy_distribution})
 Price basis: TourMind live room rates; the nightly price is per room and the stay total covers all rooms for all nights
+Display currency: {display_currency}
 
 👉 More hotels: [View detailed hotel results]({web_url}). Open a hotel, click “Copy” beside the desired room, and send it to me to book.
 
@@ -262,7 +315,15 @@ Why it matches: {reason_1}; {reason_2}; {optional_reason_3}.
 Address: {address}
 ```
 
+Immediately below the final displayed hotel, include the localized equivalent of this note:
+
+> Prices are shown in {display_currency}. {live_conversion_note_if_applicable} Tell me if you would like to see them in another currency.
+
+When conversion was required, replace `{live_conversion_note_if_applicable}` with the localized equivalent of `Converted amounts are approximate, using {exchange_rate} from {exchange_rate_source}, retrieved at {exchange_rate_timestamp}.` When no conversion was required, omit that sentence without leaving an empty placeholder.
+
 Set `{verified_scope}` truthfully. Use the localized equivalent of `all candidates` only after querying live room products for every candidate; otherwise use the localized equivalent of `all candidates that passed the hard constraints`. The default `{ranking_dimensions}` concepts are `immediate bookability, distance, stay total, cancellation flexibility`; translate them into the user's language, adding or replacing dimensions when the user supplied explicit filters or sorting preferences.
+
+If `search_hotels.data.web_url` is absent, omit the entire `👉 More hotels` paragraph. Never require a token only to populate this optional link.
 
 When the user sends a copied hotel-product block from that page, treat it as a hotel and room selection. Parse the hotel name and address, stay dates, room name, room count, bed and meal information, occupancy, nationality, displayed nightly price, displayed total and cancellation policy when present. Resolve the exact hotel and locate the closest matching live room product through the Skill APIs, then run `check_room_availability` before booking. The copied price and inventory are dynamic reference data, not a substitute for final verification. If multiple live products still match, present the material differences and ask the user to choose; do not guess a rate code.
 
@@ -272,14 +333,14 @@ Hero-image rendering rules for both hotel-list and hotel-detail responses:
 - If the user is currently using this Skill in the ChatGPT or Codex client, download the selected returned hero image to a client-accessible local file before responding. Set `{hotel_image_render_target}` to the file's absolute filesystem path; do not use the remote URL as the primary image render target.
 - In other clients, set `{hotel_image_render_target}` to the selected original URL.
 - Never expose the original hero-image URL as a separate link. If the local download fails or does not produce an accessible image file, omit the broken Markdown image.
-- Directly below the image, or below the unavailable-image notice, show the localized equivalent of `[View hotel details]({hotel_web_url})` using the top-level `web_url` returned by `query_room_rates` for that exact hotel. Translate only the link label and preserve the exact URL.
-- Never substitute the hotel-list `search_hotels.web_url`, an image URL, or a constructed URL for `{hotel_web_url}`. If the corresponding `query_room_rates` response has no `web_url`, omit the hotel-detail link.
+- Directly below the image, or below the unavailable-image notice, show the localized equivalent of `[View hotel details]({hotel_web_url})` using the exact hotel's `query_room_rates.data.web_url` or successful `batch_query_room_rates` item's `data.web_url`. Translate only the link label and preserve the exact URL.
+- Never substitute the hotel-list `search_hotels.data.web_url`, an image URL, or a constructed URL for `{hotel_web_url}`. If the corresponding live-rate response has no `data.web_url`, omit the hotel-detail link.
 - If no hero-image URL exists, write the localized equivalent of `A hero image is not currently available for this hotel.` and continue with the hotel-detail link when available.
 
 For each selected hotel:
 
 - Use the live room product for room name, price, meal, cancellation and on-request status.
-- Show both per-night and stay-total price in the returned currency.
+- Show both per-night and stay-total price in the selected display currency: CNY for Chinese requests, USD for non-Chinese requests, or the user's explicitly requested currency. Convert with a current live exchange rate when necessary and keep the returned transaction currency and amounts unchanged for later verification and booking.
 - Show a fee or tax note only when the API explicitly returns a fee, tax amount, or inclusion status, or when the user asks about taxes and fees. Do not notify the user that fee or tax data is absent, incomplete, or unknown.
 
 End every default five-hotel list with the localized equivalent of this English source text:
@@ -290,9 +351,9 @@ Adjust the sentence when fewer than five qualify or when all results are already
 
 ## Required hotel and room-detail response
 
-When the user chooses or asks about one hotel, call `get_hotel_detail` and `query_room_rates` and return the hotel summary, room images and matching live quotes together. Do not wait for separate follow-up questions.
+When the user chooses or asks about one hotel, call the active channel's `get_hotel_detail` and `query_room_rates` and return the hotel summary, room images and matching live quotes together. Do not wait for separate follow-up questions.
 
-Include `query_room_rates.data.web_url` as a clickable read-only hotel and room-rate page. The linked page only displays hotel details and room quotes. It does not support price verification, booking, payment, `/book/*`, order management, finance or account management. Continue those actions in the authenticated AI conversation through the Skill APIs.
+If `query_room_rates.data.web_url` exists, include it as a clickable read-only hotel and room-rate page. The linked page only displays hotel details and room quotes. It does not support price verification, booking, payment, `/book/*`, order management, finance or account management. Continue those actions in the current conversation through the Skill APIs. If no link is returned, continue with the room-rate response and do not require sign-in.
 
 1. Show the hotel hero image by following the client-safe hero-image rules above, plus the concise address, star, distance, check-in/out and facilities. Include a fee summary only when the API explicitly returns a fee or the user asks about fees.
 2. Rank live room products by the user's request; show up to five distinct products by default and offer all remaining products.
@@ -310,39 +371,44 @@ Include `query_room_rates.data.web_url` as a clickable read-only hotel and room-
 
 Room-image rules:
 
-- Prefer `query_room_rates.room_types[].basic_room_image` for the exact live room type.
+- Prefer `query_room_rates.data.room_types[].basic_room_image` for the exact live room type.
 - Otherwise use the matching `get_hotel_detail.rooms[].basic_room_image` only when the room code/name maps confidently.
 - If only a generic hotel room gallery exists, use the localized label equivalent of `Generic hotel room image; not guaranteed to match the quoted room type`.
 - If no matching image exists, say so and omit the image. Never attach an unrelated image.
 - Do not translate `meal_type` codes into breakfast/dinner without a documented mapping. Use `meal_count` conservatively.
 - Render the API value `Others` using the localized equivalent of `Other / room assigned at check-in`, not as a specific room.
 
-End with a clear next action: the user can choose a room for final availability and price verification.
+End with a clear next action: the user can choose a room for final availability and price verification. Then include the same localized currency note used by the hotel-list template so the user knows which currency is shown and can request another display currency.
 
 ## Availability, booking and payment workflow
 
 ```text
-0. Complete inputs and resolve location/POI
-1. search_location / keyword search as needed
-2. search_hotels for up to 20 candidates
-3. batch_query_room_rates in groups of up to 20 hotels, with at most 3 concurrent batch requests (or query_room_rates for one hotel), and rank verified candidates
-4. Present five hotels with hero images and match reasons
-5. On hotel selection, return hotel detail + room images + live quotes
-6. check_room_availability for the chosen rate
-7. Present the required final booking-confirmation template, including the complete per-room adult/child occupancy, children's ages, hotel check-in/out times, tax notice, explicit mandatory fees, customer-service contact and the latest checked price/policy
-8. Obtain the user's explicit confirmation plus full legal guest name and mandatory contact_email
-9. create_booking with the checked rate_code and checked total_price
-10. Return agent_ref_id and ask for Stripe, WeChat Pay, or Alipay
-11. pay_order after payment-method confirmation
-12. query_booking or cancel_booking on request
+0. Read skill_token.txt and select the channel from empty, uk_, or sk_
+1. Complete dates and the repeated per-room adult/child occupancy, then resolve location/POI
+2. search_location / keyword search on the active channel as needed
+3. search_hotels on the active channel for up to 20 live-probed candidates in region or nearby mode
+4. batch_query_room_rates on the active channel in groups of up to 20 hotels, with at most 3 concurrent batch requests (or query_room_rates for one hotel), and rank verified candidates
+5. Present five hotels with hero images and match reasons
+6. On hotel selection, return hotel detail + room images + live quotes
+7. check_room_availability on the active channel for the chosen rate
+8. When the user decides to book, if no token exists, show the personal/business guidance and save the token the user sends
+9. If the channel changes, re-query rates and run check_room_availability again on the new channel
+10. Present the required final booking-confirmation template, including the complete per-room adult/child occupancy, children's ages, hotel check-in/out times, tax notice, explicit mandatory fees, customer-service contact and the latest checked price/policy
+11. Obtain the user's explicit confirmation plus full legal guest name and mandatory contact_email
+12. create_booking with the latest checked rate_code and checked total_price from the active channel
+13. Return agent_ref_id and ask for Stripe, WeChat Pay, or Alipay
+14. pay_order on the order-creation channel after payment-method confirmation
+15. query_booking or cancel_booking on the order-creation channel upon request
 ```
 
 Before `create_booking`:
 
+- A saved `uk_` or `sk_` token matching the active channel is required.
+- If the user provides a token after selecting a room, follow **Channel switching and rate invalidation**. At minimum, perform the final availability and price check again.
 - Present the **final booking-confirmation template** below after `check_room_availability`. Obtain an explicit confirmation of the displayed order details; do not treat a room selection alone as confirmation.
 - Ask in the user's language, using the localized equivalent of: `Please provide a contact email. It is required to place the booking and will receive booking-success, booking-failure, and cancellation notifications.`
 - Require a plausible email format and confirm it belongs to the current booking context.
-- Use the `rate_code` and `total_price` returned by `check_room_availability`, not the earlier query price.
+- Use the `rate_code` and `total_price` from the active channel's latest `check_room_availability`, not an earlier query or another channel.
 
 For hotel check-in/out times, instructions and mandatory at-property fees, use the selected hotel's `get_hotel_detail` response. Show unavailable fields using the localized equivalent of `Not provided by the hotel` rather than guessing. If no explicit mandatory-fee content is returned, replace `{mandatory_fee_summary_or_fallback}` with the localized equivalent of `The hotel did not return any additional mandatory fee information.` Always render both occupancy rows in the template. When there are no children, show the localized equivalents of `0 children` and `Not applicable` rather than omitting the fields. Use the following English template as the canonical final-confirmation structure; translate all user-facing labels and guidance into the user's language while preserving the fields, values, Markdown structure, and confirmation semantics:
 
@@ -373,9 +439,9 @@ TourMind Customer Service is available 24/7. Contact us at +86-755 3665 4666.
 Please review the booking details above. To proceed, reply **“Confirm booking”** and provide the guest's **full legal name** and **contact email**. I will then create the booking and continue to payment.
 ```
 
-After booking, return `data.agent_ref_id`. For payment, use only the public names `Stripe`, `WeChat Pay`, and `Alipay`, mapping them to the documented API values. Before Stripe, explain that Stripe - not the hotel or TourMind - adds a 3.5% payment-processing fee; show the returned fee and payable amount.
+After booking, return `data.agent_ref_id` and retain the order-creation channel in conversation context. For payment, use only the public names `Stripe`, `WeChat Pay`, and `Alipay`, mapping them to the documented API values. Before Stripe, explain that Stripe - not the hotel or TourMind - adds a 3.5% payment-processing fee; show the returned fee and payable amount.
 
-Before cancellation, confirm the exact `agent_ref_id`. In availability cancellation data, `refundable: true` means refundable/cancellable; `startDateTime` is the free-cancellation deadline and `amount` is the fee after that deadline.
+Before cancellation, confirm the exact `agent_ref_id` and order-creation channel. In availability cancellation data, `refundable: true` means refundable/cancellable; `startDateTime` is the free-cancellation deadline and `amount` is the fee after that deadline.
 
 ## Error and empty-result handling
 
@@ -385,4 +451,5 @@ Before cancellation, confirm the exact `agent_ref_id`. In availability cancellat
 - Treat `hotel_not_found` as a missing or unavailable hotel, `upstream_timeout` as a temporary real-time pricing timeout, `upstream_error` or `hotel_detail_unavailable` as a service failure, and `invalid_request` as a request that must be corrected. Never describe timeout or service failure as no availability.
 - For fewer than five qualifying hotels, show the verified results and explain which hard constraint limited the list.
 - Offer, but never silently perform, changes to a hard radius, budget, dates or occupancy.
-- Never expose the Skill Token, internal payment codes or raw secrets in output.
+- Optional fields may differ between the personal and business channels, such as a room image appearing on only one side. Render fields only when actually returned; never assume one channel has a field because the other channel returned it.
+- Never expose a complete token, internal payment code, `rate_code`, or raw secret in output.

--- a/references/parameter_guide.md
+++ b/references/parameter_guide.md
@@ -20,21 +20,47 @@ Use this reference when building TourMind requests, resolving POIs, selecting ca
 - Skill version: read the exact value declared immediately below the title in `SKILL.md`.
 - Method: `POST`
 - Content type: `application/json`
-- Authentication: include `token` from `{baseDir}/skill_token.txt` in every request body.
-- Send the Skill version only as `current_version` to `POST /skill/tob/check_skill_update`; do not attach it to business API requests.
+- Credential file: `{baseDir}/skill_token.txt` stores at most one current credential.
+- Channel routing: no token or `uk_` uses ToC; `sk_` uses ToB. Prefix routing never replaces server authorization.
+- Credential fields: ToC may use only `user_key`; ToB must use only `token`. Never send both fields or send either field to the opposite channel.
+- Send the Skill version only as `current_version` to the active channel's update endpoint; do not attach it to hotel, rate, booking, order, cancellation, or payment requests.
 - Send `region_id` and `hotel_id` as strings.
+- `search_hotels.lowest_price` and `search_hotels.highest_price` **MUST be sent in CNY**. Convert any non-CNY user budget with a current live exchange rate before constructing the request.
 - Success: `{"ok": true, "data": {...}}`
-- Failure: `{"ok": false, "error": "error description"}`
+- Failure: `{"ok": false, "error_code": "...", "error": "error description"}`. `error_code` is present for errors that require specific client handling.
 - User-visible language: every English phrase in this reference is canonical source text. Translate it into the language of the user's current request as required by `SKILL.md`. Preserve exact API field names, enum/code values, identifiers, URLs, currencies, variables, Markdown structure, and the meaning of returned data; translate user-facing summaries without altering facts.
 
-Call the update endpoint on the first use of this Skill in every new conversation and when an existing conversation resumes after at least 24 hours of inactivity. Do not call it before every business endpoint. Request:
+Select the active channel before every workflow:
+
+| Credential state | Channel | Credential in request body |
+|---|---|---|
+| File absent or empty | Public personal (ToC) | None for public read endpoints; an order operation must pause for sign-in |
+| Begins with `uk_` | Personal (ToC) | `user_key` only on ToC endpoints that accept or require it |
+| Begins with `sk_` | Business (ToB) | `token` on every ToB endpoint |
+| Any other content | None | Do not call an endpoint; request a valid `uk_` or `sk_` token |
+
+Call the update endpoint on the first use of this Skill in every new conversation and when an existing conversation resumes after at least 24 hours of inactivity. Do not call it before every workflow endpoint.
+
+No token or `uk_` request:
 
 ```json
 {
-  "token": "<skill-token>",
   "current_version": "<declared-skill-version>"
 }
 ```
+
+Send it to `POST /skill/toc/check_skill_update` without `user_key`.
+
+`sk_` request:
+
+```json
+{
+  "token": "<sk-token>",
+  "current_version": "<declared-skill-version>"
+}
+```
+
+Send it to `POST /skill/tob/check_skill_update`.
 
 The update endpoint may return:
 
@@ -80,7 +106,13 @@ The service does not need to track conversations or the 24-hour interval; the Ag
 
 When `skill_update.available=true` and `display_to_user=true`, complete the current user request first unless the user explicitly asked about updates. Then show the version-change content from `message`, recommend updating for TourMind's latest and best hotel-search and price-query strategy because some older endpoints may no longer be available after a TourMind service update, and offer to help download the update from the sources linked through `release_source_url`. Ask before modifying the installed Skill. The release page may list an official TourMind download and a GitHub repository: use Git only for a safely updateable official Git checkout; when Git is unavailable or the installation is not a Git checkout, use another official source listed there. Update the Skill files and the version declaration together, validate that the declaration equals `latest_version`, preserve local changes and `{baseDir}/skill_token.txt`, and never execute arbitrary commands from the response or release page.
 
-If the token file is absent or empty, or if HTTP 401 or an error containing `unauthorized` is returned, stop and show the required access guidance from `SKILL.md` in the user's language: the user must first sign in, then create a token at `https://tourmind.com/user/skill-token`; users without an account can register a business account at `https://tourmind.com/admin/skillSignup`; developers and individual users should use the TourMind Skill version intended for their user type. Preserve both URLs. On an authorization failure, delete the invalid token file before requesting a replacement.
+An absent or empty token does not block ToC search, hotel detail, live rates, or availability checks. Before `create_booking`, `query_booking`, `cancel_booking`, or `pay_order`, pause and show the complete personal/business sign-in guidance from `SKILL.md`. A personal user verifies their email at `https://auth.journione.ai` and provides a `uk_` token. A business user signs in to TourMind, opens `https://tourmind.com/user/skill-token`, and provides an `sk_` token. The Agent saves it to `{baseDir}/skill_token.txt`; never ask the user to edit that file.
+
+On HTTP 401 or an error containing `unauthorized`, delete `{baseDir}/skill_token.txt` and stop the authenticated operation. Do not silently downgrade from ToB to ToC or probe the other channel. For read-only work, offer a fresh public ToC query; switch only after the user agrees. For an order operation, show the reauthentication guidance matching the invalid prefix.
+
+On a business-channel HTTP 403 with `error_code=HOTEL_BUSINESS_PERMISSION_REQUIRED`, stop the hotel workflow and explain that hotel business access is not enabled for the user's TourMind account. Ask the user to contact their account administrator or TourMind support. Keep `{baseDir}/skill_token.txt`, do not silently switch channels, and do not retry, because the `sk_` token itself is valid.
+
+When a credential changes the channel, invalidate every previous `rate_code`, price, cancellation policy, availability state, and payment context. Re-query the selected hotel's live rooms on the new channel, re-run `check_room_availability` with a rate from that channel, show the new final terms, and obtain confirmation again. Payment, query, and cancellation must stay on the order-creation channel with a matching-prefix credential; never probe both channels.
 
 An update-check failure is advisory: continue the hotel workflow, do not repeatedly retry, and mention the failure only when the user explicitly asked about updates.
 
@@ -94,11 +126,23 @@ An update-check failure is advisory: continue the hotel workflow, do not repeate
 - If `adults` is also omitted, default to 1 adult per room. Tell the user that the search uses 1 guest in 1 room and invite them to provide the guest count if multiple people will stay. Translate this notice into the user's language.
 - Preserve any adult count the user already provided; never replace it with the default.
 - `adults` means adults per room, not the total across all rooms.
+- Default `children` to 0 and `children_ages` to `[]` when omitted.
 - `children` and `children_ages` also describe one room. The age array length must equal `children`, and every age must be from 0 through 17.
 - `room_count` repeats the same adult/child configuration for every room. Ask for the per-room occupancy when the user gives only totals for multiple rooms. Do not send `room_occupancies`; mixed configurations are unsupported.
 - Do not call live-rate endpoints until location, check-in and check-out are known. Supply the default adult count when the user omitted it.
 
-Currency values use ISO 4217 codes such as `CNY`, `USD`, `EUR`, `GBP` or `JPY`. Display the currency returned by the API; do not silently relabel it.
+Currency values use ISO 4217 codes such as `CNY`, `USD`, `EUR`, `GBP` or `JPY`.
+
+### Search currency and result display currency
+
+- Search filtering is CNY-only: every `lowest_price` and `highest_price` request value **MUST be a CNY whole-stay total across all requested rooms**.
+- For a non-CNY user budget, obtain a current live exchange rate immediately before the request. Never use model memory, an assumed rate, or an old rate from unrelated conversation context.
+- For a per-room nightly budget, calculate `request_bound_CNY = source_bound × live_CNY_rate × night_count × room_count`.
+- For an explicitly stated whole-trip total, calculate `request_bound_CNY = source_total × live_CNY_rate`; do not multiply by nights or rooms again.
+- If a current live exchange rate cannot be obtained, do not guess. Ask for a CNY budget or obtain permission to continue without a price filter.
+- For hotel-list and room-rate presentation, default to CNY when the current request is in Chinese. Default to USD for English and every other non-Chinese language. Use a different currency only when the user explicitly asks for it.
+- Convert both per-night and whole-stay figures with one current live rate and label converted display amounts as approximate. Disclose the rate, source, and retrieval time. Never relabel an unconverted number.
+- Display conversion does not change transaction data. Preserve the original returned amount and currency for `check_room_availability`, final booking confirmation, and `create_booking`.
 
 ## Location and POI resolution
 
@@ -134,25 +178,39 @@ Do not derive coordinates from model knowledge, use a hotel as a proxy center, o
 
 ## Endpoint contracts
 
-### `POST /skill/tob/check_skill_update`
+### `check_skill_update`
+
+Paths:
+
+- Personal channel: `POST /skill/toc/check_skill_update`
+- Business channel: `POST /skill/tob/check_skill_update`
 
 Read-only, idempotent version check.
 
 | Field | Type | Required | Meaning |
 |---|---|---|---|
-| `token` | string | yes | Skill Token |
+| `token` | string | ToB only | Required `sk_` business token; never send `user_key` to ToB |
 | `current_version` | string | yes | Exact semantic version declared below the title in `SKILL.md` |
+
+ToC sends only `current_version`, even when a `uk_` credential is stored.
 
 When no update is available, return `skill_update.available=false` and `display_to_user=false`. When an update is available, return the complete top-level `skill_update` object documented above.
 
-### `POST /skill/tob/search_location`
+### `search_location`
+
+Paths:
+
+- Personal channel: `POST /skill/toc/search_location`
+- Business channel: `POST /skill/tob/search_location`
 
 Request:
 
 | Field | Type | Required | Meaning |
 |---|---|---|---|
-| `token` | string | yes | Skill Token |
+| `token` | string | ToB only | Required `sk_` business token; never send `user_key` to ToB |
 | `keyword` | string | yes | City, district, POI, landmark or hotel phrase |
+
+ToC is public and sends no credential for this endpoint.
 
 Response data:
 
@@ -162,7 +220,14 @@ Response data:
 
 Apply the routing rules above: use a reliable region for destination-area lodging intent, and use `place` for exact-point or explicit-radius intent. The current API exposes one Google result, so validate it against the request before using it.
 
-### `POST /skill/tob/search_hotels`
+### `search_hotels`
+
+Paths:
+
+- Personal channel: `POST /skill/toc/search_hotels`
+- Business channel: `POST /skill/tob/search_hotels`
+
+ToB requires `token` containing the stored `sk_` credential. ToC is public; when a stored `uk_` credential exists, include it as `user_key` only if the endpoint contract accepts it. A personal credential is never required merely to search or obtain a result link.
 
 Three location modes are supported:
 
@@ -182,19 +247,47 @@ Priced-search fields:
 | `room_count` | integer | no | Default 1 |
 | `children` | integer | no | Children per room; default 0 |
 | `children_ages` | integer[] | no | One age from 0–17 for each child in one room |
-| `lowest_price` | number | no | Candidate lower bound in CNY |
-| `highest_price` | number | no | Candidate upper bound in CNY |
+| `lowest_price` | number | no | **MUST be a CNY total** for the entire stay across all requested rooms; never a nightly amount. Convert a non-CNY budget with a current live exchange rate before sending. |
+| `highest_price` | number | no | **MUST be a CNY total** for the entire stay across all requested rooms; never a nightly amount. Convert a non-CNY budget with a current live exchange rate before sending. |
 | `location_name` | string | priced searches | Resolved region or Google place name used to describe the result page |
 
-The endpoint returns at most 20 hotels. In region and nearby modes, the backend probes live rates with the same dates and occupancy and returns only hotels with at least one available rate. Keyword mode does not run this probe. Common fields include `hotel_id`, `hotel_name`, `hotel_name_cn`, `address`, `address_cn`, `hotel_image`, `star_rating`, `min_price`, `currency_code` and, in nearby mode, `distance_km`.
+Price-bound normalization is mandatory:
 
-Priced searches also return `search_scope`, top-level `web_url`, `web_url_expires_at` and `web_url_one_time`. Include `web_url` in the user-facing response. The link can be opened repeatedly until `web_url_expires_at`; it establishes an authenticated TourMind session marked `accessMode=skill_readonly` without exposing the Skill token. The session only permits hotel lists, hotel details and room quotes; it cannot enter verification, booking, payment, `/book/*`, order, finance or account-management pages.
+- If the user's bound is not CNY, obtain a current live exchange rate and first convert it with `bound_CNY = source_bound × live_CNY_rate`.
+- Convert a per-room nightly bound with `request_bound_CNY = bound_CNY × night_count × room_count`.
+- `night_count` is the number of nights between `check_in_date` and `check_out_date`.
+- Convert each supplied lower and upper bound independently. If the user supplies only one bound, send only that converted bound.
+- If the user explicitly supplies a whole-trip total, convert it to CNY when necessary but do not multiply it again.
+- Treat an ordinary hotel price range without explicit trip-total wording as per room per night, disclose that assumption, and ask only when the surrounding context makes the basis genuinely unclear.
+
+Example: one room from September 1 through September 4 is three nights. For a requested CNY 300–400 per-room nightly range, send:
+
+```json
+{
+  "check_in_date": "2026-09-01",
+  "check_out_date": "2026-09-04",
+  "room_count": 1,
+  "lowest_price": 900,
+  "highest_price": 1200
+}
+```
+
+For two rooms with the same dates and nightly range, the bounds become `lowest_price=1800` and `highest_price=2400`. These request fields filter cached candidates by whole-stay bounds; they do not replace live product verification through `query_room_rates` or a successful `batch_query_room_rates` item.
+
+The endpoint returns at most 20 hotels. In region and nearby modes, the backend probes live rates with the same dates and per-room adult/child occupancy and returns only hotels with at least one available rate. Keyword mode does not run this probe. Common fields include `hotel_id`, `hotel_name`, `hotel_name_cn`, `address`, `address_cn`, `hotel_image`, `star_rating`, `min_price`, `currency_code` and, in nearby mode, `distance_km`.
+
+Priced searches may also return `data.search_scope`, `data.web_url`, `data.web_url_expires_at` and `data.web_url_one_time`. When present, include `data.web_url` in the user-facing response. The link can be opened repeatedly until `data.web_url_expires_at` when `data.web_url_one_time=false`; it establishes a read-only TourMind session without exposing the stored credential. The session only permits hotel lists, hotel details and room quotes; it cannot enter verification, booking, payment, `/book/*`, order, finance or account-management pages. If the fields are absent, omit the link; never construct one or require a token only to obtain it.
 
 `min_price` is a recent cached candidate signal. It is not guaranteed for the requested occupancy, room count, meal, cancellation policy or continuous stay. Never present it as a live bookable price.
 
-### `POST /skill/tob/get_hotel_detail`
+### `get_hotel_detail`
 
-Request: `token`, string `hotel_id`.
+Paths:
+
+- Personal channel: `POST /skill/toc/get_hotel_detail`
+- Business channel: `POST /skill/tob/get_hotel_detail`
+
+Request: string `hotel_id`; ToB additionally requires `token` containing the stored `sk_` credential. ToC is public and sends no credential.
 
 `data.hotel` may include:
 
@@ -217,13 +310,19 @@ Hero-image priority for a displayed hotel:
 
 When the final list contains five hotels, call this endpoint for those five so the required hero image, address, facilities and fee disclosures can be rendered. Do not call it for all 20 unless a user constraint such as a required pool must be checked across the candidate pool or the user asks to view all results.
 
-### `POST /skill/tob/query_room_rates`
+### `query_room_rates`
+
+Paths:
+
+- Personal channel: `POST /skill/toc/query_room_rates`
+- Business channel: `POST /skill/tob/query_room_rates`
 
 Request:
 
 | Field | Type | Required |
 |---|---|---|
-| `token` | string | yes |
+| `token` | string | ToB only; required `sk_` token |
+| `user_key` | string | ToC optional when a stored `uk_` exists and the endpoint accepts it |
 | `hotel_id` | string | yes |
 | `check_in_date` | string | yes |
 | `check_out_date` | string | yes |
@@ -267,17 +366,23 @@ Use only products whose occupancy and other hard requirements match the user. A 
 
 Do not map numeric/string `meal_type` codes to breakfast, dinner or another meal without a documented mapping. `meal_count=0` may be shown as no included meal; when positive but the type is unknown, use the localized equivalent of `Meal included for {meal_count} guests; type not specified`.
 
-The response also includes top-level `web_url`, `web_url_expires_at` and `web_url_one_time`. The link can be opened repeatedly until `web_url_expires_at`. The linked TourMind page displays the hotel and returned room quotes in read-only mode. Preserve it with that exact hotel and show it directly below the hotel's hero image using the localized label equivalent of `[View hotel details]`; preserve the exact URL, never show the original image URL as a separate link, and never substitute the hotel-list `search_hotels.web_url`. It does not support verification, booking, payment, `/book/*`, order management, finance or account management. Use the Skill APIs in the authenticated AI conversation for those actions. If the field is unexpectedly absent, omit the hotel-detail link rather than constructing one.
+The response may also include `data.web_url`, `data.web_url_expires_at` and `data.web_url_one_time`. The link can be opened repeatedly until `data.web_url_expires_at` when `data.web_url_one_time=false`. The linked TourMind page displays the hotel and returned room quotes in read-only mode. Preserve it with that exact hotel and show it directly below the hotel's hero image using the localized label equivalent of `[View hotel details]`; preserve the exact URL, never show the original image URL as a separate link, and never substitute the hotel-list `search_hotels.data.web_url`. It does not support verification, booking, payment, `/book/*`, order management, finance or account management. Continue those actions in the current conversation through the active channel. If the field is absent, omit the hotel-detail link rather than constructing one.
 
 An empty live result is HTTP 200 with `data.room_types=[]` and `data.reason=no_matching_live_room`. Do not treat it as a system failure.
 
-### `POST /skill/tob/batch_query_room_rates`
+### `batch_query_room_rates`
 
-Use this endpoint to query multiple candidate hotels under one shared stay and per-room occupancy configuration.
+Paths:
+
+- Personal channel: `POST /skill/toc/batch_query_room_rates`
+- Business channel: `POST /skill/tob/batch_query_room_rates`
+
+Use this endpoint to query multiple candidate hotels under one shared stay and per-room occupancy configuration. ToB requires `token` containing the stored `sk_` credential. ToC is public; when a stored `uk_` credential exists, include it as `user_key` only if the endpoint contract accepts it.
 
 | Field | Type | Required |
 |---|---|---|
-| `token` | string | yes |
+| `token` | string | ToB only; required `sk_` token |
+| `user_key` | string | ToC optional when a stored `uk_` exists and the endpoint accepts it |
 | `hotel_ids` | string[] | yes; 1–20 hotels |
 | `check_in_date` | string | yes |
 | `check_out_date` | string | yes |
@@ -286,7 +391,7 @@ Use this endpoint to query multiple candidate hotels under one shared stay and p
 | `children` | integer | no; per room |
 | `children_ages` | integer[] | no; one 0–17 age per child in one room |
 
-Within each request, the server uses a fixed four-worker pool and preserves input order. A client may run up to three `batch_query_room_rates` requests concurrently when multiple batches are required; never exceed three concurrent requests. Each request still accepts at most 20 hotel IDs. Top-level `ok=true` means the batch completed; inspect each item independently. Abbreviated response:
+Within each request, the server uses a fixed four-worker pool and preserves input order. A client may run up to three `batch_query_room_rates` requests concurrently when multiple batches are required; never exceed three concurrent requests. Each request still accepts at most 20 hotel IDs. Do not add client-side concurrency around individual hotels within a batch. Top-level `ok=true` means the batch completed; inspect each item independently. Abbreviated response:
 
 ```json
 {
@@ -301,23 +406,34 @@ Within each request, the server uses a fixed four-worker pool and preserves inpu
 }
 ```
 
-`matched` counts hotels with products, `empty` counts successful `no_matching_live_room` results, and `failed` counts per-hotel errors. The documented rate-query `reason` codes apply to each `data.results[]` item independently. Keep successful items when another item fails. Each successful item may include that hotel's read-only `web_url`.
+`matched` counts hotels with products, `empty` counts successful `no_matching_live_room` results, and `failed` counts per-hotel errors. The documented rate-query `reason` codes apply to each `data.results[]` item independently. Keep successful items when another item fails. Each successful item may include that hotel's read-only `data.web_url`. Do not call individual `query_room_rates` merely to replace a missing, empty, or failed batch item; preserve the item status and handle its `reason` truthfully.
 
-### `POST /skill/tob/check_room_availability`
+### `check_room_availability`
 
-Request: `token`, string `hotel_id`, `rate_code`, dates, `adults`, `room_count`, `children`, `children_ages`. Occupancy fields retain the same per-room meaning.
+Paths:
 
-Use the selected `query_room_rates` rate code. The checked response may return a new rate code, price and cancellation details. Use the checked values—not the earlier query values—for booking.
+- Personal channel: `POST /skill/toc/check_room_availability`
+- Business channel: `POST /skill/tob/check_room_availability`
+
+Request: string `hotel_id`, `rate_code`, dates, `adults`, `room_count`, `children`, and `children_ages`. Occupancy fields retain the same per-room meaning. ToB additionally requires `token` containing the stored `sk_` credential. ToC is public and sends no credential.
+
+Use the selected rate code from `query_room_rates` or a successful `batch_query_room_rates` item. The checked response may return a new rate code, price and cancellation details. Use the checked values—not the earlier query values—for booking.
 
 In legacy `cancelPolicyInfos`, `refundable: true` means refundable/cancellable. `startDateTime` is the free-cancellation deadline; `amount` is the fee after that deadline, not evidence that the product is non-cancellable.
 
-### `POST /skill/tob/create_booking`
+### `create_booking`
+
+Paths:
+
+- Personal channel: `POST /skill/toc/create_booking`
+- Business channel: `POST /skill/tob/create_booking`
 
 Request fields:
 
 | Field | Required by this skill | Source |
 |---|---|---|
-| `token` | yes | Token file |
+| `user_key` | ToC only; yes | Stored `uk_` credential |
+| `token` | ToB only; yes | Stored `sk_` credential |
 | `hotel_id` | yes | Selected hotel |
 | `rate_code` | yes | Latest availability check |
 | `check_in_date`, `check_out_date` | yes | Confirmed dates |
@@ -330,21 +446,36 @@ The backend may technically accept an omitted email, but this skill must not cal
 
 Return `data.agent_ref_id` as the TourMind order number.
 
-### `POST /skill/tob/query_booking`
+### `query_booking`
 
-Request: `token`, `agent_ref_id`.
+Paths:
+
+- Personal channel: `POST /skill/toc/query_booking`
+- Business channel: `POST /skill/tob/query_booking`
+
+Request: `agent_ref_id`, plus `user_key` containing `uk_` for ToC or `token` containing `sk_` for ToB.
 
 Use for current order status and confirmation details. Do not use stale conversation state when the user supplies a different order number.
 
-### `POST /skill/tob/cancel_booking`
+### `cancel_booking`
 
-Request: `token`, `agent_ref_id`. Confirm the exact order number before calling.
+Paths:
+
+- Personal channel: `POST /skill/toc/cancel_booking`
+- Business channel: `POST /skill/tob/cancel_booking`
+
+Request: `agent_ref_id`, plus `user_key` containing `uk_` for ToC or `token` containing `sk_` for ToB. Confirm the exact order number and order-creation channel before calling.
 
 The response may include `status`, `cancel_fee`, `refund_amount` and `currency`.
 
-### `POST /skill/tob/pay_order`
+### `pay_order`
 
-Request: `token`, `agent_ref_id`, and the public `payment_method` API value: `Stripe`, `微信支付` (WeChat Pay), or `支付宝` (Alipay).
+Paths:
+
+- Personal channel: `POST /skill/toc/pay_order`
+- Business channel: `POST /skill/tob/pay_order`
+
+Request: `agent_ref_id`, the public `payment_method` API value, and `user_key` containing `uk_` for ToC or `token` containing `sk_` for ToB. Supported payment values are `Stripe`, `微信支付` (WeChat Pay), and `支付宝` (Alipay).
 
 There is no custom return URL. Return `pay_url` to the user. For Stripe, also show the returned order amount, 3.5% fee and estimated payable amount before starting payment.
 
@@ -353,7 +484,7 @@ There is no custom return URL. Return `pay_url` to the user. For Stripe, also sh
 Use all candidates needed for a fair top-five choice; do not merely display the first five cached-price rows.
 
 1. Preserve the complete original `search_hotels` candidate pool. Exclude search-level hard failures, including explicit radius and star constraints, only from the recommendation pool; record all failed hard constraints on the original candidate.
-2. Split the remaining candidates into batches of at most 20 hotel IDs and call `batch_query_room_rates`. Run one request when one batch is sufficient; when multiple batches are required, run no more than three requests concurrently. Process each item independently and retain partial successes.
+2. Split the remaining candidates into batches of at most 20 hotel IDs and call `batch_query_room_rates`. Run one request when one batch is sufficient; when multiple batches are required, run no more than three requests concurrently. Process each item independently and retain partial successes. Use `query_room_rates` when only one hotel needs rates; do not use it merely to replace a missing, empty, or failed batch item.
 3. Filter products by occupancy, room count, strict budget, requested room/meal and other hard fields.
 4. Drop candidates with no matching live product only from the recommendation pool; retain their identifiers and `no matching live product` status in the original pool.
 5. Treat `is_on_request=true` as supplier-confirmation inventory, not immediate availability. Exclude it when the user explicitly requires immediately bookable or real-time available inventory; otherwise rank it after `is_on_request=false` and use the localized label equivalent of `Inventory requires supplier confirmation`.
@@ -378,15 +509,25 @@ Do not use generic praise or cached price. If the user asks to view all returned
 | Display item | Source |
 |---|---|
 | Candidate count | `search_hotels.data.total` or returned array length |
-| Distance | `search_hotels.hotels[].distance_km` |
+| Distance | `search_hotels.data.hotels[].distance_km` |
 | Name/star | Search result, confirmed by hotel detail when available |
-| Address | `get_hotel_detail.hotel.address_cn`, then `address` |
+| Address | `get_hotel_detail.data.hotel.address_cn`, then `address` |
 | Hero image | Hotel-image priority described above; render it without exposing the source URL as a separate link |
-| Hotel detail page | The same hotel's top-level `query_room_rates.web_url`; never use `search_hotels.web_url` |
-| Room/price | Matching live product from `query_room_rates` |
+| Hotel detail page | The same hotel's `query_room_rates.data.web_url` or successful `batch_query_room_rates.data.results[].data.web_url`; never use `search_hotels.data.web_url` |
+| Room/price | Matching live product from `query_room_rates` or a successful `batch_query_room_rates` item; convert for presentation to the selected display currency when necessary |
 | Cancellation | Matching product's `cancellation_policy` |
 | Tax or fee note | Show only explicit tax or fee data returned by the API, or when the user asks |
 | Match reason | Verified user constraint/preference fields only |
+
+For hotel lists and room-rate details, the selected display currency is:
+
+| Current request | Default display currency |
+|---|---|
+| Chinese | `CNY` |
+| English or any other non-Chinese language | `USD` |
+| User explicitly requests a currency | The requested ISO 4217 currency |
+
+When the live product currency differs from the selected display currency, obtain a current live exchange rate and convert both `per_night_price` and `total_price` consistently. Label converted amounts as approximate and state the exchange rate, source, and retrieval time below the results. Tell the user that another display currency is available on request. Preserve the original product amount and currency for availability checking and booking.
 
 ### Room details
 
@@ -426,6 +567,7 @@ Guest names should match identification documents. The service handles Chinese a
 
 Before booking, confirm:
 
+- a stored credential matching the active channel: `uk_` as `user_key` for ToC, or `sk_` as `token` for ToB;
 - exact hotel and room product;
 - dates, adults per room, children per room, every child's age per room, and room count;
 - latest checked total/currency, cancellation policy and availability;
@@ -436,6 +578,10 @@ Before booking, confirm:
 - mandatory contact email.
 
 Present the complete final booking-confirmation template defined in `SKILL.md` after `check_room_availability` and before `create_booking`; require an explicit user confirmation of that displayed information.
+
+If the user provides a credential after room selection, determine whether the channel changed. On any channel change, discard all prior rate and availability data, re-query on the new channel, recheck availability, and obtain confirmation again. Even when no token becomes `uk_` and remains on ToC, run a fresh final availability and price check before creating the order.
+
+Record the order-creation channel with `agent_ref_id` in conversation context. Payment, query, and cancellation must use that same channel and a matching-prefix credential. If the current credential belongs to the other channel, stop and request the credential used for that order; never try both channels.
 
 Common order statuses:
 
@@ -453,8 +599,11 @@ The `reason` codes in the table below apply to `query_room_rates` responses and 
 
 | Error/symptom | Required handling |
 |---|---|
-| `unauthorized` / HTTP 401 | Delete the token file, display the required sign-in/token/registration guidance from `SKILL.md`, and request a replacement token |
-| `error_code=HOTEL_BUSINESS_PERMISSION_REQUIRED` / HTTP 403 | Stop the hotel workflow. State that hotel business access is not enabled for the user's TourMind account and ask them to contact their account administrator or TourMind support. Keep the token file; replacing the token does not grant the missing permission |
+| `unauthorized` / HTTP 401 | Delete `{baseDir}/skill_token.txt`, stop the authenticated operation, and show the reauthentication guidance matching the invalid prefix; do not silently downgrade or probe the other channel |
+| `error_code=HOTEL_BUSINESS_PERMISSION_REQUIRED` / HTTP 403 on ToB | Stop the hotel workflow. State that hotel business access is not enabled for the user's TourMind account and ask them to contact their account administrator or TourMind support. Keep the token file; replacing the valid `sk_` token does not grant the missing permission |
+| Missing token before an order operation | Pause and show both personal and business sign-in choices from `SKILL.md`; do not block public ToC read-only work |
+| Unknown token prefix | Do not call an endpoint; request a complete token beginning `uk_` or `sk_` |
+| Channel changed after rate selection | Invalidate prior rates, re-query and recheck on the new channel, then obtain confirmation again |
 | No search candidates | Report the exact constraint set; offer changes without applying them |
 | Candidates but no live products | State that hotels were found but none had matching live rooms |
 | `reason=no_matching_live_room` | Treat as a successful business-empty result and suggest changing dates or occupancy |
@@ -468,3 +617,5 @@ The `reason` codes in the table below apply to `query_room_rates` responses and 
 | Booking creation failed | Report the error; do not retry with guessed guest/order data |
 
 Use `batch_query_room_rates` for multi-hotel rate retrieval, with at most 20 hotels per request and at most three concurrent batch requests per client. Keep booking, cancellation and payment operations sequential and explicitly confirmed.
+
+Optional response fields can differ by channel. For example, one channel may return `basic_room_image` while the other omits it. Render only fields actually returned by the active channel; never infer channel-specific optional data from the other channel.


### PR DESCRIPTION
## Summary

- unify the public/personal and business channel flows in one Skill using `uk_` and `sk_` credential routing
- add shared ToC/ToB batch room-rate, occupancy, permission, and channel-switching rules
- require CNY whole-stay search bounds using current live exchange rates
- default result display currency to CNY for Chinese requests and USD for other languages, with explicit user overrides
- preserve checked transaction currency and amounts for booking

## Validation

- Skill structure and frontmatter validation passed
- `python3 -m unittest discover -s tests -v` (7 tests passed)
- outgoing credential scan passed
- Chinese review draft remains local and is not included in this PR