### PR TITLE
Clarify Stripe fee refund policy

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ description: >
 license: MIT
 metadata:
   author: TourMind
-  version: "1.0.7"
+  version: "1.0.8"
 ---
 
 # TourMind Booking Skill
@@ -457,9 +457,9 @@ TourMind Customer Service is available 24/7. Contact us at +86-755 3665 4666.
 Please review the booking details above. To proceed, reply **“Confirm booking”** and provide the guest's **full legal name** and **contact email**. I will then create the booking and continue to payment.
 ```
 
-After booking, return `data.agent_ref_id` and retain the order-creation channel in conversation context. For payment, use only the public names `Stripe`, `WeChat Pay`, and `Alipay`, mapping them to the documented API values. Before Stripe, explain that Stripe - not the hotel or TourMind - adds a 3.5% payment-processing fee; show the returned fee and payable amount.
+After booking, return `data.agent_ref_id` and retain the order-creation channel in conversation context. For payment, use only the public names `Stripe`, `WeChat Pay`, and `Alipay`, mapping them to the documented API values. Before Stripe, explain that Stripe - not the hotel or TourMind - adds a 3.5% payment-processing fee; show the returned fee and payable amount. Clearly disclose that once charged, the Stripe processing fee is non-refundable, including when the booking is later cancelled within the hotel's free-cancellation period. Obtain the user's explicit acknowledgement of both the fee and this non-refundable rule before calling `pay_order` with Stripe.
 
-Before cancellation, confirm the exact `agent_ref_id` and order-creation channel. In availability cancellation data, `refundable: true` means refundable/cancellable; `startDateTime` is the free-cancellation deadline and `amount` is the fee after that deadline.
+Before cancellation, confirm the exact `agent_ref_id` and order-creation channel. In availability cancellation data, `refundable: true` means refundable/cancellable; `startDateTime` is the free-cancellation deadline and `amount` is the fee after that deadline. If the order was paid through Stripe, warn the user before cancellation that the room-charge refund follows the hotel's cancellation policy, but the charged Stripe processing fee will not be refunded even during the free-cancellation period. Obtain explicit cancellation confirmation after showing this warning.
 
 ## Error and empty-result handling
 

--- a/references/parameter_guide.md
+++ b/references/parameter_guide.md
@@ -496,7 +496,7 @@ Paths:
 
 Request: `agent_ref_id`, the public `payment_method` API value, and `user_key` containing `uk_` for ToC or `token` containing `sk_` for ToB. Supported payment values are `Stripe`, `微信支付` (WeChat Pay), and `支付宝` (Alipay).
 
-There is no custom return URL. Return `pay_url` to the user. For Stripe, also show the returned order amount, 3.5% fee and estimated payable amount before starting payment.
+There is no custom return URL. Return `pay_url` to the user. For Stripe, also show the returned order amount, 3.5% fee and estimated payable amount before starting payment. Disclose that once charged, the Stripe processing fee is non-refundable even if the booking is later cancelled within the hotel's free-cancellation period, and obtain the user's explicit acknowledgement before calling the payment endpoint.
 
 ## Candidate verification and ranking
 
@@ -577,8 +577,9 @@ Tax and fees:
 Stripe:
 
 - The 3.5% fee is Stripe payment processing, not room rate, hotel tax or a TourMind booking surcharge.
-- Show it only when Stripe is being considered or selected.
+- Show it only when Stripe is being considered or selected. Before starting payment, disclose that once charged, this processing fee is non-refundable, including when the booking is later cancelled within the hotel's free-cancellation period, and obtain the user's explicit acknowledgement.
 - Use returned `fee_amount` and `payable_amount`; do not recompute when values are available.
+- Before cancelling an order paid through Stripe, explain that the eligible room-charge refund follows the hotel's cancellation policy but the charged Stripe processing fee will not be refunded, even during the free-cancellation period. Obtain explicit cancellation confirmation after this disclosure.
 
 ## Booking and order rules
 


### PR DESCRIPTION
## Summary

- disclose before Stripe payment that the 3.5% processing fee is non-refundable once charged
- clarify that this remains true when the hotel booking is cancelled within its free-cancellation period
- repeat the warning before cancellation of a Stripe-paid order and require explicit confirmation
- bump the Skill version to 1.0.8
